### PR TITLE
Turn CLR exceptions into v8 Error objects

### DIFF
--- a/Source/Noesis.Javascript/JavascriptExternal.cpp
+++ b/Source/Noesis.Javascript/JavascriptExternal.cpp
@@ -199,9 +199,13 @@ JavascriptExternal::GetProperty(uint32_t iIndex)
 			System::Object^ object = type->InvokeMember("Item", System::Reflection::BindingFlags::GetProperty, nullptr, self, args,  nullptr);
 			return JavascriptInterop::ConvertToV8(object);
 		}
+		catch(System::Reflection::TargetInvocationException^ exception)
+		{
+			v8::ThrowException(JavascriptInterop::ConvertToV8(exception->InnerException));
+		}
 		catch(System::Exception^ Exception)
 		{
-			v8::ThrowException(JavascriptInterop::ConvertToV8(Exception->ToString()));
+			v8::ThrowException(JavascriptInterop::ConvertToV8(Exception));
 		}
 	}
 


### PR DESCRIPTION
...in order to get stack traces when caught again later.  Also fixed
error handling for int-indexed getters.  Fixed stack limit setting to
handler pointer-arithmetic underflow.
