### PR TITLE
Fixed choosing incorrect method overload

### DIFF
--- a/Source/Noesis.Javascript/JavascriptInterop.cpp
+++ b/Source/Noesis.Javascript/JavascriptInterop.cpp
@@ -579,9 +579,9 @@ JavascriptInterop::Invoker(const v8::FunctionCallbackInfo<Value>& iArgs)
 			cli::array<System::Object^>^ arguments;
 
 			// Match arguments & parameters counts.  We will add nulls where
-            // we have imsufficient parameters.  Note that this checking does
+            // we have insufficient parameters.  Note that this checking does
             // not detect where nulls have been supplied (or insufficient parameters
-            // have been spplied), but the corresponding parameter cannot accept
+            // have been supplied), but the corresponding parameter cannot accept
             // a null.  This will trigger an exception during invocation.
 			if (iArgs.Length() <= parametersInfo->Length)
 			{
@@ -626,10 +626,32 @@ JavascriptInterop::Invoker(const v8::FunctionCallbackInfo<Value>& iArgs)
 					bestMethodArguments = arguments;
 					bestMethodMatchedArgs = match;
 				}
-
+				else if (match == bestMethodMatchedArgs)
+				{
+					if (suppliedArguments->Length == parametersInfo->Length) // Prefer method with the most matches and the same length of arguments
+					{
+						bestMethod = method;
+						bestMethodArguments = arguments;
+						bestMethodMatchedArgs = match;
+					}
+				}
+				
+				/*
+					THE CODE BELOW MAY CHOOSE A METHOD PREMATURLY
+					for example:
+					
+					public void test(string a, int b, bool c) { ... }
+					public void test(string a, int b, bool c, float d) { ... }
+					
+					and then invoke it this way in JavaScript:
+					
+					test("some text", 1234, true, 3.14);
+					
+					it'll invoke the first one instead of the second because it found 3 matches and there are 3 arguments.
+				*/
 				// skip lookup if all args matched
-				if (match == arguments->Length)
-					break;
+				//if (match == arguments->Length)
+					//break;
 			}
 		}
 	}


### PR DESCRIPTION
The algorithm for choosing the right method for an overloaded function may choose the wrong one in some cases. Example:

public void test(string a, int b, bool c) { ... }
public void test(string a, int b, bool c, float d) { ... }

and then invoke it this way in JavaScript:

test("some text", 1234, true, 3.14);

it'll invoke the first one instead of the second because it found 3 matches and there are 3 arguments for the first function.
