### PR TITLE
Make test independent of user culture

### DIFF
--- a/Tests/Noesis.Javascript.Tests/ExceptionTests.cs
+++ b/Tests/Noesis.Javascript.Tests/ExceptionTests.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Globalization;
+using System.Threading;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using FluentAssertions;
 
@@ -13,6 +15,7 @@ namespace Noesis.Javascript.Tests
         public void SetUp()
         {
             _context = new JavascriptContext();
+            Thread.CurrentThread.CurrentUICulture = new CultureInfo("en-US");
         }
 
         [TestCleanup]


### PR DESCRIPTION
Hi,

the test `HandleInvalidArgumentsInIndexerCall` fails if executed on an operating system with a language other than english because .NET localizes the exception message. Make it culture independent by setting the current thread's UI culture.

Thanks!