### PR TITLE
Stopped functions from trying to clean themselves up in their finaliz…

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ The following warnings are expected:
 
 Also note that when using the DLL built from source, you will need to add a Post Build Step to your consuming project, which copies the v8 DLLs and .bin files into your output directory.  See Noesis.Javascript.Tests.csproj for an example, noting that it has some extra sections manually inserted to define `V8Platform`.
 
+
+Updating v8
+===========
+The log at https://docs.google.com/a/g7.org/document/d/1g8JFi8T_oAE_7uAri7Njtig7fKaPDfotU6huOa1alds/edit may help, if it is still being updated.
+
+
 Running Tests
 =============
 

--- a/Source/Noesis.Javascript/JavascriptContext.h
+++ b/Source/Noesis.Javascript/JavascriptContext.h
@@ -182,7 +182,7 @@ internal:
 
 	Handle<ObjectTemplate> GetObjectWrapperTemplate();
 
-	bool IsDisposed();
+	void RegisterFunction(System::Object^ f);
 
 	static void FatalErrorCallbackMember(const char* location, const char* message);
 
@@ -207,7 +207,9 @@ protected:
 	// the context is destroyed.
 	System::Collections::Generic::Dictionary<System::Object ^, WrappedJavascriptExternal> ^mExternals;
 
-	bool mIsDisposed;
+	// Stores every JavascriptFunction we create.  Ensures we dispose of them
+	// all.
+	System::Collections::Generic::List<System::Object ^> ^mFunctions;
 
 	// Keeping track of recursion.
 	[System::ThreadStaticAttribute] static JavascriptContext ^sCurrentContext;

--- a/Source/Noesis.Javascript/JavascriptFunction.cpp
+++ b/Source/Noesis.Javascript/JavascriptFunction.cpp
@@ -21,28 +21,15 @@ JavascriptFunction::JavascriptFunction(v8::Handle<v8::Object> iFunction, Javascr
 
 	mFuncHandle = new Persistent<Function>(context->GetCurrentIsolate(), Handle<Function>::Cast(iFunction));
 	mContext = context;
+
+	mContext->RegisterFunction(this);
 }
 
 JavascriptFunction::~JavascriptFunction()
 {
 	if(mFuncHandle) 
 	{
-		if (mContext && !mContext->IsDisposed())
-		{
-			JavascriptScope scope(mContext);
-			mFuncHandle->Reset();
-		}
-		delete mFuncHandle;
-		mFuncHandle = nullptr;
-	}
-	System::GC::SuppressFinalize(this);
-}
-
-JavascriptFunction::!JavascriptFunction() 
-{
-	if(mFuncHandle) 
-	{
-		if (mContext && !mContext->IsDisposed())
+		if (mContext)
 		{
 			JavascriptScope scope(mContext);
 			mFuncHandle->Reset();

--- a/Source/Noesis.Javascript/JavascriptFunction.h
+++ b/Source/Noesis.Javascript/JavascriptFunction.h
@@ -24,7 +24,6 @@ public ref class JavascriptFunction
 public:
 	JavascriptFunction(v8::Handle<v8::Object> iFunction, JavascriptContext^ context);
 	~JavascriptFunction();
-	!JavascriptFunction();
 
 	System::Object^ Call(... cli::array<System::Object^>^ args);
 


### PR DESCRIPTION
…ers, because the context is probably already gone and even checking mIsDisposed can crash.  Instead all functions are freed when the context is disposed, which will probably cause crashes if C# still has a reference.  That situation could be considered a user error, but it would be better if they could somehow throw a sensible exception.