### PR TITLE
Added access to current stack frame during execution

### DIFF
--- a/Source/Noesis.Javascript/JavaScript.Net.vcxproj
+++ b/Source/Noesis.Javascript/JavaScript.Net.vcxproj
@@ -162,6 +162,7 @@
     <ClInclude Include="JavascriptExternal.h" />
     <ClInclude Include="JavascriptFunction.h" />
     <ClInclude Include="JavascriptInterop.h" />
+    <ClInclude Include="JavascriptStackFrame.h" />
     <ClInclude Include="SystemInterop.h" />
   </ItemGroup>
   <ItemGroup>

--- a/Source/Noesis.Javascript/JavaScript.Net.vcxproj.filters
+++ b/Source/Noesis.Javascript/JavaScript.Net.vcxproj.filters
@@ -33,6 +33,9 @@
     <ClInclude Include="JavascriptFunction.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="JavascriptStackFrame.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="AssemblyInfo.cpp">

--- a/Source/Noesis.Javascript/JavascriptContext.h
+++ b/Source/Noesis.Javascript/JavascriptContext.h
@@ -34,6 +34,8 @@
 #include <string>
 #include <vector>
 
+#include "JavascriptStackFrame.h"
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 namespace Noesis { namespace Javascript {
@@ -146,6 +148,8 @@ public:
 	virtual System::Object^ Run(System::String^ iScript, System::String^ iScriptResourceName);
 		
 	property static System::String^ V8Version { System::String^ get(); }
+
+    System::Collections::Generic::List<JavascriptStackFrame^>^ GetCurrentStack(int maxDepth);
 
 	void TerminateExecution();
 

--- a/Source/Noesis.Javascript/JavascriptStackFrame.h
+++ b/Source/Noesis.Javascript/JavascriptStackFrame.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <v8.h>
+using namespace v8;
+
+namespace Noesis {
+    namespace Javascript {
+        public ref class JavascriptStackFrame
+        {
+        public:
+            property int LineNumber {
+                public: int get() { return mLineNumber; }
+                internal: void set(int value) { mLineNumber = value; }
+            }
+
+            property int Column {
+                public: int get() { return mColumn; }
+                internal: void set(int value) { mColumn = value; }
+            }
+
+            property int ScriptId {
+                public: int get() { return mScriptId; }
+                internal: void set(int value) { mScriptId = value; }
+            }
+
+            property System::String^ ScriptName {
+                public: System::String^ get() { return mScriptName; }
+                internal: void set(System::String^ value) { mScriptName = value; }
+            }
+
+            property System::String^ ScriptNameOrSourceURL {
+                public: System::String^ get() { return mScriptNameOrSourceURL; }
+                internal: void set(System::String^ value) { mScriptNameOrSourceURL = value; }
+            }
+
+            property System::String^ FunctionName {
+                public: System::String^ get() { return mFunctionName; }
+                internal: void set(System::String^ value) { mFunctionName = value; }
+            }
+
+            property bool IsEval {
+                public: bool get() { return mIsEval; }
+                internal: void set(bool value) { mIsEval = value; }
+            }
+
+            property bool IsConstructor {
+                public: bool get() { return mIsConstructor; }
+                internal: void set(bool value) { mIsConstructor = value; }
+            }
+
+            property bool IsWasm {
+                public: bool get() { return mIsWasm; }
+                internal: void set(bool value) { mIsWasm = value; }
+            }
+
+        private:
+            int mLineNumber;
+            int mColumn;
+            int mScriptId;
+            System::String^ mScriptName;
+            System::String^ mScriptNameOrSourceURL;
+            System::String^ mFunctionName;
+            bool mIsEval;
+            bool mIsConstructor;
+            bool mIsWasm;
+        };
+    }
+}

--- a/Tests/Noesis.Javascript.Tests/AccessToStackTraceTest.cs
+++ b/Tests/Noesis.Javascript.Tests/AccessToStackTraceTest.cs
@@ -1,0 +1,60 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using FluentAssertions;
+using System.Linq;
+using System.Collections.Generic;
+
+namespace Noesis.Javascript.Tests
+{
+    [TestClass]
+    public class AccessToStackTraceTest
+    {
+        private class StracktraceExporter
+        {
+            public JavascriptContext context { get; set; }
+
+            public List<JavascriptStackFrame> frames(int depth)
+            {
+                return context.GetCurrentStack(depth);
+            }
+        }
+
+        [TestMethod]
+        public void TestSingleFrame()
+        {
+            JavascriptContext context = new JavascriptContext();
+            context.SetParameter("obj", new StracktraceExporter { context = context });
+            var frames = (object[])context.Run("obj.frames(1);", "Single Frame");
+
+            var frame = (JavascriptStackFrame)frames.Single();
+            frame.ScriptName.Should().Be("Single Frame");
+            frame.ScriptNameOrSourceURL.Should().Be("Single Frame");
+            frame.FunctionName.Should().Be("");
+            frame.IsConstructor.Should().Be(false);
+            frame.IsEval.Should().Be(false);
+            frame.IsWasm.Should().Be(false);
+            frame.LineNumber.Should().Be(1);
+            frame.Column.Should().Be(5);
+        }
+
+        [TestMethod]
+        public void TestUnnamedFrame()
+        {
+            JavascriptContext context = new JavascriptContext();
+            context.SetParameter("obj", new StracktraceExporter { context = context });
+            context.Run("obj.frames(1)[0].ScriptName;").Should().Be(null);
+        }
+
+        [TestMethod]
+        public void TestNestedFrame()
+        {
+            JavascriptContext context = new JavascriptContext();
+            context.SetParameter("obj", new StracktraceExporter { context = context });
+            context.Run("function func(depth, frame) {return obj.frames(depth)[frame];}", "func");
+
+            context.Run("func(1, 0).ScriptName;", "bar").Should().Be("func");
+
+            context.Run("func(2, 0).ScriptName;", "baz").Should().Be("func");
+            context.Run("func(2, 1).ScriptName;", "baz").Should().Be("baz");
+        }
+    }
+}

--- a/Tests/Noesis.Javascript.Tests/Noesis.Javascript.Tests.csproj
+++ b/Tests/Noesis.Javascript.Tests/Noesis.Javascript.Tests.csproj
@@ -79,6 +79,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AccessorInterceptorTests.cs" />
+    <Compile Include="AccessToStackTraceTest.cs" />
     <Compile Include="ConvertFromJavascriptTests.cs" />
     <Compile Include="ConvertToJavascriptTests.cs" />
     <Compile Include="ExceptionTests.cs" />


### PR DESCRIPTION
This allows C# callbacks to retrieve the context in which they are executed. The context
is copied so that it is safe to store the object regardless of the underlying
v8::StackFrame lifetime.