### PR TITLE
Prevent double initalization when using multiple app domains

### DIFF
--- a/Tests/Noesis.Javascript.Tests/MultipleAppDomainsTest.cs
+++ b/Tests/Noesis.Javascript.Tests/MultipleAppDomainsTest.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Reflection;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Noesis.Javascript.Tests
+{
+    [TestClass]
+    public class MultipleAppDomainsTest
+    {
+        private void ConstructContextInNewDomain()
+        {
+            var domainSetup = new AppDomainSetup { ApplicationBase = AppDomain.CurrentDomain.BaseDirectory };
+            var domain = AppDomain.CreateDomain(typeof(MultipleAppDomainsTest).FullName, null, domainSetup);
+            var javascriptNetAssembly = domain.Load(typeof(JavascriptContext).Assembly.FullName);
+            domain.CreateInstance(typeof(JavascriptContext).Assembly.FullName, typeof(JavascriptContext).FullName);
+        }
+
+        [TestMethod]
+        public void ConstructionContextInTwoDifferentAppDomainTests()
+        {
+            ConstructContextInNewDomain();
+            ConstructContextInNewDomain();
+        }
+    }
+}

--- a/Tests/Noesis.Javascript.Tests/Noesis.Javascript.Tests.csproj
+++ b/Tests/Noesis.Javascript.Tests/Noesis.Javascript.Tests.csproj
@@ -89,6 +89,7 @@
     <Compile Include="JavascriptFunctionTests.cs" />
     <Compile Include="MemoryLeakTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="MultipleAppDomainsTest.cs" />
     <Compile Include="VersionStringTests.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Mstest, IIS might use multiple AppDomains which trigger multiple loads
of the library and thus multiple static constructor executions. This
means that v8 was initialized multiple times.
Since v8 lives independently of AppDomains this would lead to errors when
creating a second AppDomain.