### PR TITLE
Made use in multiple AppDomains thread-safe

### DIFF
--- a/Source/Noesis.Javascript/JavascriptContext.cpp
+++ b/Source/Noesis.Javascript/JavascriptContext.cpp
@@ -115,7 +115,8 @@ namespace Noesis { namespace Javascript {
 
 static JavascriptContext::JavascriptContext()
 {
-	UnmanagedInitialisation();
+    System::Threading::Mutex mutex(true, "FA12B681-E968-4D3A-833D-43B25865BEF1");
+    UnmanagedInitialisation();
 }
 
 


### PR DESCRIPTION
Unfortunately std::mutex is not allowed in CLR code. Using monitors on
static CLR Objects also won't do the trick since those will obviously
also differ for each AppDomain. Thus I ended up using a named mutex.

This is not ideal since it also locks over process boundaries (which is
not necessary in this case), but hopefully this will not hurt.

The atomic_flag is still required since otherwise a boolean flag might
live in a register, resulting in an outdated read.

Followup of
https://github.com/JavascriptNet/Javascript.Net/pull/53#issuecomment-416512050