### PR TITLE
Removed manual conversion to local time in date conversions

### DIFF
--- a/Source/Noesis.Javascript/JavascriptInterop.cpp
+++ b/Source/Noesis.Javascript/JavascriptInterop.cpp
@@ -354,10 +354,10 @@ JavascriptInterop::ConvertObjectFromV8(Handle<Object> iObject, ConvertedObjects 
 System::DateTime^
 JavascriptInterop::ConvertDateFromV8(Handle<Value> iValue)
 {
-	System::DateTime^ startDate = gcnew System::DateTime(1970, 1, 1);
+	System::DateTime^ startDate = gcnew System::DateTime(1970, 1, 1, 0, 0, 0, 0, System::DateTimeKind::Utc);
 	double milliseconds = iValue->NumberValue();
 	System::TimeSpan^ timespan = System::TimeSpan::FromMilliseconds(milliseconds);
-	return System::DateTime(timespan->Ticks + startDate->Ticks).ToLocalTime();
+    return System::DateTime(timespan->Ticks + startDate->Ticks).ToLocalTime();
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Source/Noesis.Javascript/SystemInterop.cpp
+++ b/Source/Noesis.Javascript/SystemInterop.cpp
@@ -337,8 +337,8 @@ SystemInterop::ConvertToSystemString(std::string iString)
 double
 SystemInterop::ConvertFromSystemDateTime(System::DateTime^ iDateTime) 
 {
-    System::DateTime^ startDate = gcnew System::DateTime(1970, 1, 1);
-	System::TimeSpan^ timespan = *iDateTime - *startDate;
+    System::DateTime^ startDate = gcnew System::DateTime(1970, 1, 1, 0, 0, 0, 0, System::DateTimeKind::Utc);
+	System::TimeSpan^ timespan = iDateTime->ToUniversalTime() - *startDate;
 
 	return timespan->TotalMilliseconds;
 }

--- a/Source/Noesis.Javascript/SystemInterop.cpp
+++ b/Source/Noesis.Javascript/SystemInterop.cpp
@@ -337,8 +337,8 @@ SystemInterop::ConvertToSystemString(std::string iString)
 double
 SystemInterop::ConvertFromSystemDateTime(System::DateTime^ iDateTime) 
 {
-	System::DateTime^ startDate = gcnew System::DateTime(1970, 1, 1);
-	System::TimeSpan^ timespan = System::TimeSpan::FromTicks(iDateTime->Ticks - startDate->Ticks);
+    System::DateTime^ startDate = gcnew System::DateTime(1970, 1, 1);
+	System::TimeSpan^ timespan = *iDateTime - *startDate;
 
 	return timespan->TotalMilliseconds;
 }

--- a/Tests/Noesis.Javascript.Tests/ConvertFromJavascriptTests.cs
+++ b/Tests/Noesis.Javascript.Tests/ConvertFromJavascriptTests.cs
@@ -109,14 +109,6 @@ namespace Noesis.Javascript.Tests
         }
 
         [TestMethod]
-        public void ReadDate()
-        {
-            _context.Run("var myDate = new Date(2010,9,10)");
-
-            _context.GetParameter("myDate").Should().BeOfType<DateTime>().Which.Should().Be(new DateTime(2010, 10, 10));
-        }
-
-        [TestMethod]
         public void ReadObject()
         {
             _context.Run(@"var myObject = new Object();

--- a/Tests/Noesis.Javascript.Tests/ConvertToJavascriptTests.cs
+++ b/Tests/Noesis.Javascript.Tests/ConvertToJavascriptTests.cs
@@ -135,16 +135,6 @@ namespace Noesis.Javascript.Tests
         }
 
         [TestMethod]
-        public void SetDateTime()
-        {
-            _context.SetParameter("val", new DateTime(2010, 10, 10, 0, 0, 0, DateTimeKind.Utc));
-
-            _context.Run("val.getUTCFullYear()").Should().BeOfType<int>().Which.Should().Be(2010);
-            _context.Run("val.getUTCMonth()").Should().BeOfType<int>().Which.Should().Be(9);
-            _context.Run("val.getUTCDate()").Should().BeOfType<int>().Which.Should().Be(10);
-        }        
-        
-        [TestMethod]
         public void SetObject()
         {
             _context.SetParameter("val", new ConvertToJavascriptTests());

--- a/Tests/Noesis.Javascript.Tests/DateTest.cs
+++ b/Tests/Noesis.Javascript.Tests/DateTest.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using FluentAssertions;
+
+namespace Noesis.Javascript.Tests
+{
+    [TestClass]
+    public class DateTest
+    {
+        private JavascriptContext _context;
+
+        [TestInitialize]
+        public void SetUp()
+        {
+            _context = new JavascriptContext();
+        }
+
+        [TestCleanup]
+        public void TearDown()
+        {
+            _context.Dispose();
+        }
+
+        [TestMethod]
+        public void SetDateTime()
+        {
+            _context.SetParameter("val", new DateTime(2010, 10, 10, 0, 0, 0, DateTimeKind.Utc));
+
+            _context.Run("val.getUTCFullYear()").Should().BeOfType<int>().Which.Should().Be(2010);
+            _context.Run("val.getUTCMonth()").Should().BeOfType<int>().Which.Should().Be(9);
+            _context.Run("val.getUTCDate()").Should().BeOfType<int>().Which.Should().Be(10);
+        }
+
+        [TestMethod]
+        public void SetAndReadDateTimeUtc()
+        {
+            var dateTime = new DateTime(2010, 10, 10, 0, 0, 0, DateTimeKind.Utc);
+            _context.SetParameter("val", dateTime);
+
+            var dateFromV8 = (DateTime) _context.Run("val");
+            dateFromV8.ToUniversalTime().Should().Be(dateTime);
+        }
+
+        [TestMethod]
+        public void SetAndReadDateTimeLocal()
+        {
+            var dateTime = new DateTime(2010, 10, 10, 0, 0, 0, DateTimeKind.Local);
+            _context.SetParameter("val", dateTime);
+
+            _context.Run("val").Should().Be(dateTime);
+        }
+
+        [TestMethod]
+        public void SetAndReadDateTimeUnspecified()
+        {
+            var dateTime = new DateTime(2010, 10, 10);
+            _context.SetParameter("val", dateTime);
+
+            _context.Run("val").Should().Be(dateTime);
+        }
+
+        [TestMethod]
+        public void CreateCurrentDateInJavaScript()
+        {
+            DateTime currentTimeAsReportedByV8 = (DateTime)_context.Run("new Date()");
+            (currentTimeAsReportedByV8 - DateTime.Now).TotalSeconds.Should().BeLessThan(1, "Dates should be mostly equal");
+        }
+
+        [TestMethod]
+        public void CreateFixedDateInJavaScript()
+        {
+            DateTime dateAsReportedByV8 = (DateTime)_context.Run("new Date(2010, 9, 10)");
+            dateAsReportedByV8.Should().Be(new DateTime(2010, 10, 10));
+        }
+    }
+}

--- a/Tests/Noesis.Javascript.Tests/Noesis.Javascript.Tests.csproj
+++ b/Tests/Noesis.Javascript.Tests/Noesis.Javascript.Tests.csproj
@@ -91,6 +91,7 @@
     <Compile Include="MemoryLeakTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="MultipleAppDomainsTest.cs" />
+    <Compile Include="DateTest.cs" />
     <Compile Include="VersionStringTests.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Calling `ToLocalTime()` leads to changes of the hour component. Since in JavaScript Date is basically simply a number starting from 1970-01-01 UTC we should not do any conversions here. This also means that the test which simply checked that `new Date(2010, 9, 10)` equals `new DateTime(2010, 10, 10)` was wrong. C# does not do any conversions by default, so `new DateTime(2010, 10, 10)` does not specificy any timezone. The JavaScript code should match the UTC Date of 2010-10-10 (00:00:00) converted to the local timezone, for example, 2010-10-09 (22:00:00) for MESZ (GMT+2).