### PR TITLE
Provide static method to set engine flags

### DIFF
--- a/Source/Noesis.Javascript/JavascriptContext.cpp
+++ b/Source/Noesis.Javascript/JavascriptContext.cpp
@@ -30,6 +30,7 @@
 #include <msclr\lock.h>
 #include <vcclr.h>
 #include <msclr\marshal.h>
+#include <msclr\marshal_cppstd.h>
 #include <signal.h>
 #include "libplatform/libplatform.h"
 
@@ -193,6 +194,14 @@ void JavascriptContext::SetFatalErrorHandler(FatalErrorHandler^ handler)
 	if (handler == nullptr)
 		throw gcnew System::ArgumentNullException("handler");
 	fatalErrorHandler = handler;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+void JavascriptContext::SetFlags(System::String^ flags)
+{
+    std::string convertedFlags = msclr::interop::marshal_as<std::string>(flags);
+    v8::V8::SetFlagsFromString(convertedFlags.c_str(), convertedFlags.length());
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Source/Noesis.Javascript/JavascriptContext.h
+++ b/Source/Noesis.Javascript/JavascriptContext.h
@@ -166,6 +166,8 @@ public:
 	delegate void FatalErrorHandler(System::String^ location, System::String^ message);
 	static void SetFatalErrorHandler(FatalErrorHandler^ handler);
 
+    static void SetFlags(System::String^ flags);
+
 	////////////////////////////////////////////////////////////
 	// Internal methods
 	////////////////////////////////////////////////////////////

--- a/Tests/Noesis.Javascript.Tests/FlagsTest.cs
+++ b/Tests/Noesis.Javascript.Tests/FlagsTest.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Noesis.Javascript.Tests
+{
+    [TestClass]
+    public class FlagsTest
+    {
+        [TestMethod]
+        public void CanUseEngineFlagsToSpecifyStrictMode()
+        {
+            JavascriptContext.SetFlags("--use_strict");
+            Action action = () =>
+            {
+                using (var context = new JavascriptContext())
+                    context.Run("globalVariable = 1;");
+            };
+            action.ShouldThrowExactly<JavascriptException>().WithMessage("ReferenceError: globalVariable is not defined");
+            JavascriptContext.SetFlags("--nouse_strict");
+        }
+    }
+}

--- a/Tests/Noesis.Javascript.Tests/Noesis.Javascript.Tests.csproj
+++ b/Tests/Noesis.Javascript.Tests/Noesis.Javascript.Tests.csproj
@@ -84,6 +84,7 @@
     <Compile Include="ConvertToJavascriptTests.cs" />
     <Compile Include="ExceptionTests.cs" />
     <Compile Include="FatalErrorHandlerTests.cs" />
+    <Compile Include="FlagsTest.cs" />
     <Compile Include="InternationalizationTests.cs" />
     <Compile Include="IsolationTests.cs" />
     <Compile Include="JavascriptFunctionTests.cs" />


### PR DESCRIPTION
This can be used to set arbitrary [engine flags](https://github.com/v8/v8/blob/master/src/flag-definitions.h). E.g. to
* enforce strict mode
* set maximum stack size when embedding in an IIS process (which has only 512KB of stack)
* use experimental Javascript features
* etc.