### PR TITLE
Add support for conversion of regular expression types

### DIFF
--- a/Source/Noesis.Javascript/JavascriptInterop.cpp
+++ b/Source/Noesis.Javascript/JavascriptInterop.cpp
@@ -374,17 +374,19 @@ JavascriptInterop::ConvertDateFromV8(Handle<Value> iValue)
 System::Text::RegularExpressions::Regex^
 JavascriptInterop::ConvertRegexFromV8(Handle<Value> iValue)
 {
-    auto regexp = Handle<RegExp>::Cast(iValue->ToObject(JavascriptContext::GetCurrentIsolate()));
-    auto jsFlags = regexp->GetFlags();
-    auto jsPattern = regexp->GetSource();
-
     using RegexOptions = System::Text::RegularExpressions::RegexOptions;
-    auto flags = RegexOptions::ECMAScript;
+
+    Handle<RegExp> regexp = Handle<RegExp>::Cast(iValue->ToObject(JavascriptContext::GetCurrentIsolate()));
+    Local<String> jsPattern = regexp->GetSource();
+    RegExp::Flags jsFlags = regexp->GetFlags();
+
+    System::String^ pattern = safe_cast<System::String^>(ConvertFromV8(jsPattern));
+    RegexOptions flags = RegexOptions::ECMAScript;
     if (jsFlags & RegExp::Flags::kIgnoreCase)
         flags = flags | RegexOptions::IgnoreCase;
     if (jsFlags & RegExp::Flags::kMultiline)
         flags = flags | RegexOptions::Multiline;
-    auto pattern = gcnew System::String((wchar_t*)*String::Value(JavascriptContext::GetCurrentIsolate(), jsPattern));
+
     return gcnew System::Text::RegularExpressions::Regex(pattern, flags);
 }
 

--- a/Source/Noesis.Javascript/JavascriptInterop.h
+++ b/Source/Noesis.Javascript/JavascriptInterop.h
@@ -94,6 +94,8 @@ private:
 
 	static v8::Handle<v8::Value> ConvertFromSystemArray(System::Array^ iArray);
 
+    static v8::Handle<v8::Value> ConvertFromSystemRegex(System::Text::RegularExpressions::Regex^ iRegex);
+
 	static v8::Handle<v8::Value> ConvertFromSystemDictionary(System::Object^ iObject);
 
 	static v8::Handle<v8::Value> ConvertFromSystemList(System::Object^ iObject);

--- a/Source/Noesis.Javascript/JavascriptInterop.h
+++ b/Source/Noesis.Javascript/JavascriptInterop.h
@@ -90,6 +90,8 @@ private:
 
 	static System::DateTime^ ConvertDateFromV8(Handle<Value> iValue);
 
+    static System::Text::RegularExpressions::Regex^ ConvertRegexFromV8(Handle<Value> iValue);
+
 	static v8::Handle<v8::Value> ConvertFromSystemArray(System::Array^ iArray);
 
 	static v8::Handle<v8::Value> ConvertFromSystemDictionary(System::Object^ iObject);

--- a/Tests/Noesis.Javascript.Tests/ConvertFromJavascriptTests.cs
+++ b/Tests/Noesis.Javascript.Tests/ConvertFromJavascriptTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using FluentAssertions;
+using System.Text.RegularExpressions;
 
 namespace Noesis.Javascript.Tests
 {
@@ -106,6 +107,24 @@ namespace Noesis.Javascript.Tests
             _context.Run("var myBool = true");
 
             _context.GetParameter("myBool").Should().BeOfType<bool>().Which.Should().BeTrue();
+        }
+
+        [TestMethod]
+        public void ReadRegExpLiteral()
+        {
+            _context.Run("var myRegExp = /abc/gim");
+
+            var regex = _context.GetParameter("myRegExp");
+            regex.Should().BeOfType<Regex>().Which.ShouldBeEquivalentTo(new Regex("abc", RegexOptions.ECMAScript | RegexOptions.IgnoreCase | RegexOptions.Multiline));
+        }
+
+        [TestMethod]
+        public void ReadRegExpObject()
+        {
+            _context.Run("var myRegExp = new RegExp('abc', 'gim')");
+
+            var regex = _context.GetParameter("myRegExp");
+            regex.Should().BeOfType<Regex>().Which.ShouldBeEquivalentTo(new Regex("abc", RegexOptions.ECMAScript | RegexOptions.IgnoreCase | RegexOptions.Multiline));
         }
 
         [TestMethod]

--- a/Tests/Noesis.Javascript.Tests/ConvertToJavascriptTests.cs
+++ b/Tests/Noesis.Javascript.Tests/ConvertToJavascriptTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using FluentAssertions;
+using System.Text.RegularExpressions;
 
 namespace Noesis.Javascript.Tests
 {
@@ -132,6 +133,31 @@ namespace Noesis.Javascript.Tests
             _context.SetParameter("val", true);
 
             _context.Run("val === true").Should().BeOfType<bool>().Which.Should().BeTrue();
+        }
+
+        [TestMethod]
+        public void SetRegexWithoutECMAScriptFlagThrowsException()
+        {
+            Action action = () => _context.SetParameter("val", new Regex("abc"));
+            action.ShouldThrow<Exception>().WithMessage("Only regular expressions with the ECMAScript option can be converted.");
+        }
+
+        [TestMethod]
+        public void SetRegexWithECMAScriptFlagOnly()
+        {
+            _context.SetParameter("val", new Regex("abc", RegexOptions.ECMAScript));
+
+            _context.Run("val.source === 'abc'").Should().BeOfType<bool>().Which.Should().BeTrue();
+            _context.Run("val.flags === ''").Should().BeOfType<bool>().Which.Should().BeTrue();
+        }
+
+        [TestMethod]
+        public void SetRegexWithFlags()
+        {
+            _context.SetParameter("val", new Regex("abc", RegexOptions.ECMAScript | RegexOptions.IgnoreCase | RegexOptions.Multiline));
+
+            _context.Run("val.source === 'abc'").Should().BeOfType<bool>().Which.Should().BeTrue();
+            _context.Run("val.flags === 'im'").Should().BeOfType<bool>().Which.Should().BeTrue();
         }
 
         [TestMethod]


### PR DESCRIPTION
This PR adds support to convert `RegExp` literals and objects to their corresponding .NET `Regex` equivalent and vice versa as accurate as this is possible. Syntactically they should be pretty identical as far as the pattern is concerned.

## JS -> .NET
* Always sets the `ECMAScript` compatibility option
* Converts the `i` and `m` flags to the equivalent `IgnoreCase` and `MultiLine` options
* Ignores every other flag

## .NET -> JS
* Throws an exception if the `ECMAScript` compatibility option is not set (**this is up for debate since this would be a breaking change**)
* Converts the `IgnoreCase` and `MultiLine` options to the equivalent `i` and `m` flags
* Ignores every other flag

Let me know what you think.

Thanks!