### PR TITLE
 Pass default value if optional parameters are omitted using undefined and ignore redundant parameters

### DIFF
--- a/Source/Noesis.Javascript/JavascriptInterop.cpp
+++ b/Source/Noesis.Javascript/JavascriptInterop.cpp
@@ -667,6 +667,17 @@ JavascriptInterop::IndexSetter(uint32_t iIndex, Local<Value> iValue, const Prope
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
+int CountMaximumNumberOfParameters(cli::array<System::Reflection::MemberInfo^>^ members)
+{
+    int maxParameters = 0;
+    for (int i = 0; i < members->Length; i++)
+    {
+        System::Reflection::MethodInfo^ method = (System::Reflection::MethodInfo^) members[i];
+        maxParameters = System::Math::Max(maxParameters, method->GetParameters()->Length);
+    }
+    return maxParameters;
+}
+
 void
 JavascriptInterop::Invoker(const v8::FunctionCallbackInfo<Value>& iArgs)
 {
@@ -692,12 +703,7 @@ JavascriptInterop::Invoker(const v8::FunctionCallbackInfo<Value>& iArgs)
 
 	if (members->Length > 0 && members[0]->MemberType == System::Reflection::MemberTypes::Method)
 	{
-        int maxParameters = 0;
-        for (int i = 0; i < members->Length; i++)
-        {
-            System::Reflection::MethodInfo^ method = (System::Reflection::MethodInfo^) members[i];
-            maxParameters = System::Math::Max(maxParameters, method->GetParameters()->Length);
-        }
+        int maxParameters = CountMaximumNumberOfParameters(members);
 
 		// parameters
 		suppliedArguments = gcnew cli::array<System::Object^>(maxParameters);

--- a/Source/Noesis.Javascript/JavascriptInterop.cpp
+++ b/Source/Noesis.Javascript/JavascriptInterop.cpp
@@ -692,10 +692,17 @@ JavascriptInterop::Invoker(const v8::FunctionCallbackInfo<Value>& iArgs)
 
 	if (members->Length > 0 && members[0]->MemberType == System::Reflection::MemberTypes::Method)
 	{
+        int maxParameters = 0;
+        for (int i = 0; i < members->Length; i++)
+        {
+            System::Reflection::MethodInfo^ method = (System::Reflection::MethodInfo^) members[i];
+            maxParameters = System::Math::Max(maxParameters, method->GetParameters()->Length);
+        }
+
 		// parameters
-		suppliedArguments = gcnew cli::array<System::Object^>(iArgs.Length());
+		suppliedArguments = gcnew cli::array<System::Object^>(maxParameters);
 		ConvertedObjects already_converted;
-		for (int i = 0; i < iArgs.Length(); i++)
+		for (int i = 0; i < maxParameters; i++)
 			suppliedArguments[i] = ConvertFromV8(iArgs[i], already_converted);
 		
 		// look for best matching method
@@ -710,7 +717,7 @@ JavascriptInterop::Invoker(const v8::FunctionCallbackInfo<Value>& iArgs)
             // not detect where nulls have been supplied (or insufficient parameters
             // have been supplied), but the corresponding parameter cannot accept
             // a null.  This will trigger an exception during invocation.
-			if (iArgs.Length() <= parametersInfo->Length)
+			if (suppliedArguments->Length <= parametersInfo->Length)
 			{
 				int match = 0;
 				int failed = 0;

--- a/Source/Noesis.Javascript/JavascriptInterop.cpp
+++ b/Source/Noesis.Javascript/JavascriptInterop.cpp
@@ -719,7 +719,8 @@ JavascriptInterop::Invoker(const v8::FunctionCallbackInfo<Value>& iArgs)
 				arguments = gcnew cli::array<System::Object^>(parametersInfo->Length);  // trailing parameters will be null
 				for (int p = 0; p < suppliedArguments->Length; p++)
 				{
-					System::Type^ paramType = parametersInfo[p]->ParameterType;
+                    System::Reflection::ParameterInfo^ parameter = parametersInfo[p];
+					System::Type^ paramType = parameter->ParameterType;
 
 					if (suppliedArguments[p] != nullptr)
 					{
@@ -740,9 +741,15 @@ JavascriptInterop::Invoker(const v8::FunctionCallbackInfo<Value>& iArgs)
 							}
 						}
 					}
+                    else if (parameter->IsOptional && parameter->HasDefaultValue && iArgs[p]->IsUndefined())
+                    {
+                        // pass default value if parameter is optional and undefined was supplied as an argument
+                        arguments[p] = parameter->DefaultValue;
+                    }
 				}
-                for (int p = suppliedArguments->Length; p < arguments->Length; p++) // set default values if there are optional parameters
+                for (int p = suppliedArguments->Length; p < arguments->Length; p++)
                 {
+                    // pass default values if there are optional parameters
                     System::Reflection::ParameterInfo^ parameter = parametersInfo[p];
                     if (parameter->IsOptional && parameter->HasDefaultValue)
                         arguments[p] = parameter->DefaultValue;

--- a/Tests/Noesis.Javascript.Tests/ConvertFromJavascriptTests.cs
+++ b/Tests/Noesis.Javascript.Tests/ConvertFromJavascriptTests.cs
@@ -36,7 +36,7 @@ namespace Noesis.Javascript.Tests
                 return s;
             }
 
-            public string methodWithRequiredAndDefaultParameters(int i, string s = "", bool b = true)
+            public string methodWithRequiredAndDefaultParameters(int i, string s = "abc", bool b = true)
             {
                 return String.Format("i: {0}, s: {1}, b: {2}", i, s, b);
             }
@@ -258,7 +258,7 @@ namespace Noesis.Javascript.Tests
             _context.SetParameter("obj", obj);
             var result = _context.Run("obj.methodWithRequiredAndDefaultParameters(1)");
 
-            result.Should().Be("i: 1, s: , b: True");
+            result.Should().Be("i: 1, s: abc, b: True");
         }
 
         [TestMethod]
@@ -269,6 +269,17 @@ namespace Noesis.Javascript.Tests
             var result = _context.Run("obj.methodWithRequiredAndDefaultParameters(1, 'test', false)");
 
             result.Should().Be("i: 1, s: test, b: False");
+        }
+
+        [TestMethod]
+        [Ignore]
+        public void MethodCallWithRequiredAndDefaultParameters_PassingOnlyOneOptionalActualParameterLeavingTheMiddleOneUndefined()
+        {
+            var obj = new TypedPropertiesClass();
+            _context.SetParameter("obj", obj);
+            var result = _context.Run("obj.methodWithRequiredAndDefaultParameters(1, undefined, false)");
+
+            result.Should().Be("i: 1, s: abc, b: False");
         }
     }
 }

--- a/Tests/Noesis.Javascript.Tests/ConvertFromJavascriptTests.cs
+++ b/Tests/Noesis.Javascript.Tests/ConvertFromJavascriptTests.cs
@@ -202,6 +202,16 @@ namespace Noesis.Javascript.Tests
         }
 
         [TestMethod]
+        public void MethodCallWithoutParameters_RedundantArgumentsAreIgnored()
+        {
+            var obj = new TypedPropertiesClass();
+            _context.SetParameter("obj", obj);
+            var result = _context.Run("obj.methodWithoutParameters(42)");
+
+            result.Should().Be(1);
+        }
+
+        [TestMethod]
         public void MethodCallWithParameter()
         {
             var obj = new TypedPropertiesClass();

--- a/Tests/Noesis.Javascript.Tests/ConvertFromJavascriptTests.cs
+++ b/Tests/Noesis.Javascript.Tests/ConvertFromJavascriptTests.cs
@@ -272,7 +272,16 @@ namespace Noesis.Javascript.Tests
         }
 
         [TestMethod]
-        [Ignore]
+        public void MethodCallWithRequiredAndDefaultParameters_PassingUndefinedForAllOptionalActualParameter()
+        {
+            var obj = new TypedPropertiesClass();
+            _context.SetParameter("obj", obj);
+            var result = _context.Run("obj.methodWithRequiredAndDefaultParameters(1, undefined, undefined)");
+
+            result.Should().Be("i: 1, s: abc, b: True");
+        }
+
+        [TestMethod]
         public void MethodCallWithRequiredAndDefaultParameters_PassingOnlyOneOptionalActualParameterLeavingTheMiddleOneUndefined()
         {
             var obj = new TypedPropertiesClass();


### PR DESCRIPTION
Hi,

I forgot two important test cases in my last PR
- [x] If a method parameter is omitted using the value `undefined` explicitly (e.g. to only omit an optional parameter in the middle of the parameter list) then the default value must be passed if the parameter has one. 
- [x] If more parameters are passed than necessary the redundant parameters must be ignored.

Sorry for the noise.

**Example in JS**:
```js
function test(n, s = 'abc', b = true) {
    return `n: ${n} s: ${s} b: ${b}`;
}

test(1, undefined, false); // "n: 1 s: abc b: false"
test(1, undefined, false, 1, 2, 3); // "n: 1 s: abc b: false"
```

Thanks!