### PR TITLE
Use ReferenceEquals to prevent infinite recursion

### DIFF
--- a/Source/Noesis.Javascript/JavascriptFunction.cpp
+++ b/Source/Noesis.Javascript/JavascriptFunction.cpp
@@ -75,8 +75,8 @@ System::Object^ JavascriptFunction::Call(... cli::array<System::Object^>^ args)
 
 bool JavascriptFunction::operator==(JavascriptFunction^ func1, JavascriptFunction^ func2)
 {
-    bool func1_null = func1 == nullptr,
-         func2_null = func2 == nullptr;
+    bool func1_null = ReferenceEquals(func1, nullptr),
+         func2_null = ReferenceEquals(func2, nullptr);
     if (func1_null != func2_null)
 		return false;
     if (func1_null && func2_null)

--- a/Tests/Noesis.Javascript.Tests/JavascriptFunctionTests.cs
+++ b/Tests/Noesis.Javascript.Tests/JavascriptFunctionTests.cs
@@ -34,6 +34,18 @@ namespace Noesis.Javascript.Tests
         }
 
         [TestMethod]
+        public void EqualsOperatorWorksWithFunctionObjects()
+        {
+            _context.Run("a = function(a, b) { return a + b; }");
+
+            JavascriptFunction funcObj = _context.GetParameter("a") as JavascriptFunction;
+            (funcObj == null).Should().BeFalse();
+            (funcObj != null).Should().BeTrue();
+            (null == funcObj).Should().BeFalse();
+            (null != funcObj).Should().BeTrue();
+        }
+
+        [TestMethod]
         public void GetNamedFunctionFromJsContext()
         {
             _context.Run("function test(a, b) { return a + b; }");


### PR DESCRIPTION
Sorry I didn't catch the infinite recursion in the review of #66 . This PR fixes that.