### PR TITLE
Fixing more memory leaks

### DIFF
--- a/Source/Noesis.Javascript/JavascriptContext.cpp
+++ b/Source/Noesis.Javascript/JavascriptContext.cpp
@@ -183,6 +183,7 @@ JavascriptContext::~JavascriptContext()
             if (function != nullptr)
                 delete function;
         }
+        mFunctions->Clear();
 		delete mContext;
 		delete mExternals;
 		delete mFunctions;
@@ -502,8 +503,18 @@ JavascriptContext::GetObjectWrapperTemplate()
 void
 JavascriptContext::RegisterFunction(System::Object^ f)
 {
-    // Note that while we do store WeakReferences, we never clean up this hashtable,
-    // so it will just grow and grow.
+    if (mFunctions->Count > 100)
+    {
+        for (int i = mFunctions->Count - 1; i >= 0; i--)
+        {
+            auto weakReference = mFunctions[i];
+            auto f = safe_cast<JavascriptFunction^>(weakReference->Target);
+            if (!weakReference->IsAlive || f == nullptr || f->mFuncHandle == nullptr)
+            {
+                mFunctions->RemoveAt(i);
+            }
+        }
+    }
 	mFunctions->Add(gcnew System::WeakReference(f));
 }
 

--- a/Source/Noesis.Javascript/JavascriptExternal.cpp
+++ b/Source/Noesis.Javascript/JavascriptExternal.cpp
@@ -59,6 +59,10 @@ JavascriptExternal::JavascriptExternal(System::Object^ iObject)
 
 JavascriptExternal::~JavascriptExternal()
 {
+    for each (WrappedMethod wrapped in mMethods->Values)
+        delete wrapped.Pointer;
+    mMethods->Clear();
+    delete mMethods;
 	mObjectHandle.Free();
 }
 

--- a/Source/Noesis.Javascript/JavascriptFunction.cpp
+++ b/Source/Noesis.Javascript/JavascriptFunction.cpp
@@ -39,11 +39,6 @@ JavascriptFunction::~JavascriptFunction()
 	}
 }
 
-JavascriptFunction::!JavascriptFunction()
-{
-    delete this;
-}
-
 System::Object^ JavascriptFunction::Call(... cli::array<System::Object^>^ args)
 {
     if (mFuncHandle == nullptr)

--- a/Source/Noesis.Javascript/JavascriptFunction.h
+++ b/Source/Noesis.Javascript/JavascriptFunction.h
@@ -26,7 +26,6 @@ public ref class JavascriptFunction
 public:
 	JavascriptFunction(v8::Handle<v8::Object> iFunction, JavascriptContext^ context);
 	~JavascriptFunction();
-    !JavascriptFunction();
 
 	System::Object^ Call(... cli::array<System::Object^>^ args);
 
@@ -36,7 +35,7 @@ public:
 	virtual bool Equals(Object^ other) override;
 
 private:
-	v8::Persistent<v8::Function>* mFuncHandle;
+    v8::Persistent<v8::Function>* mFuncHandle;
 	JavascriptContext^ mContext;
 };
 

--- a/Source/Noesis.Javascript/JavascriptFunction.h
+++ b/Source/Noesis.Javascript/JavascriptFunction.h
@@ -33,9 +33,9 @@ public:
 	bool Equals(JavascriptFunction^ other);
 	
 	virtual bool Equals(Object^ other) override;
-
-private:
+internal:
     v8::Persistent<v8::Function>* mFuncHandle;
+private:
 	JavascriptContext^ mContext;
 };
 


### PR DESCRIPTION
This PR attempts to mitigate more memory leaks.
## Introduction / TL;DR
Usually `JavascriptContext` objects are lightweight and can be created for every script execution and then directly be disposed afterwards. If you are using this pattern you simply won't encounter the more severe version of the memory leaks this PR tries to mitigate.

You are probably only impacted if you reuse `JavascriptContext` objects in a pool. This is necessary in use cases where the contexts must be populated with alot of custom types or prepared with bigger scripts causing a tremendous performance impact if contexts are created for every script execution.

## Fixes
* [x] Clean up weak references of `JavascriptFunction` objects periodically (as proposed in #65)
* [x] Release references to managed objects that are set using `SetParameter` if the same global name is used in a subsequent call to `SetParameter`
* [x] Cleanup dictionary of cached methods when disposing a `JavascriptExternal`
* [ ] Cleanup `JavascriptExternal`/`WrappedJavascriptExternal` using an API method

## Details
### Clean up weak references of `JavascriptFunction` objects periodically
The periodic cleanup runs every time the number of weak references to `JavascriptFunction` objects exceeds 100 and removes all elements that are either flagged as not alive (the GC collected them already), or whose `mFuncHandle` is null (those that are collected by the GC but not yet flagged). The latter results in a more aggressive cleanup. For this to work we make `mFuncHandle` internal rather than private.

Without this cleanup we measured a memory leak of about 50 MB / 100,000 functions using the memory leak test. Note that the `JavascriptFunction` objects needs to be disposed after usage on the client side, if you want to profit from the aggressive cleanup.

###  Release references to managed objects that are set using `SetParameter`
If you set a global variable using 
```cs
ctx.SetParameter("myGlobal", myObject);
```
the instance `myObject` cannot be garbage collected until the `JavascriptContext` is disposed. If you reuse the context this leads to a memory leak.

We mitigate that by releasing the underlying pointer that's used in V8 as soon as the same global variable is overridden:
```cs
ctx.SetParameter("myGlobal", myObject2);
// or
ctx.SetParameter("myGlobal", null);
```
This way the garbage collector is enabled to collect those object instances as soon as they are no longer referenced on the client side. To profit from this improvement you need to set global variables to `null` before reusing the context.

### Cleanup dictionary of cached methods when disposing a `JavascriptExternal`
If a `JavascriptExternal` is disposed by the previous mechanism we also clean up all the references to the `WrappedMethod` instances so that they don't leak memory.

### Cleanup `JavascriptExternal`/`WrappedJavascriptExternal` using an API method
I wasn't able to fix this yet. @oliverbock Any suggestions?

**Note:** For us this is the most severe memory leak. We have some batch processes which spin up thousands of managed objects that are relatively large. Those are fed into the context as global objects so that the batch process itself can be customized using JavaScript. One of these **leaks ~2.5 GB in ten minutes** that can only be garbage collected if we dispose the context. However, as context creation is expensive for us, we can't do that every time.

#### Reproduction
The leak happens because of nested objects that are referenced from the global variables we set. Due to one of the previously discussed fixes the global objects could be garbage collected but the following dictionary still holds references to the nested objects leading to this severe leak.
```cs
System::Collections::Generic::Dictionary<System::Object ^, WrappedJavascriptExternal> ^mExternals;
```

This is reproducible in the Fiddling project with the follwing code:
```cs
public class Product
{
    public decimal Price { get; set; }
    public Foo Foo { get; set; }
}

public class Foo
{
    public byte[] Bar { get; set; }

    public Foo()
    {
        Bar = new byte[1000];
        Bar[0] = 42;
    }
}

static void ForceGC()
{
    GC.Collect();
    GC.WaitForPendingFinalizers();
    GC.Collect();
}

static void Main(string[] args)
{
    using (var context = new JavascriptContext())
    { // breakpoint and snapshot here
        for (var i = 0; i < 2000; i++)
        {
            context.SetParameter("product", new Product { Price = 1.0m, Foo = new Foo() });
            context.Run("product.Price + product.Foo.Bar[0]");
            context.SetParameter("product", null);
            // context.ResetWrappedExternals(); // this is the attempted fix
        }
        ForceGC(); // breakpoint and snapshot here
    } // breakpoint and snapshot here
} // breakpoint and snapshot here
```

#### Analysis
Using the memory profiler of the *Diagostics Tools* in Visual Studio we get the following output, where the last snapshot was taken after the context was disposed:
![grafik](https://user-images.githubusercontent.com/25029871/49931603-8817ac80-fec7-11e8-90f3-32c11fb59f52.png)
![grafik](https://user-images.githubusercontent.com/25029871/49931451-2bb48d00-fec7-11e8-9223-576833a267c7.png)

#### Attempted solution
I tried to create an API method in `JavascriptContext` to clean up these externals when the context is put back into the pool, but I get memory access exceptions in our codebase and I haven't found a way to reproduce them yet in the Fiddling project.
```cpp
void JavascriptContext::ResetWrappedExternals()
{
    v8::Locker v8ThreadLock(isolate);
    v8::Isolate::Scope isolate_scope(isolate);
    for each (WrappedJavascriptExternal wrapped in mExternals->Values)
        delete wrapped.Pointer;
    mExternals->Clear();
}
```
But if you enable the call to `ResetWrappedExternals` in the code above there seem to be no more memory leaks:
![grafik](https://user-images.githubusercontent.com/25029871/49931734-d3ca5600-fec7-11e8-920d-0bcfe25ebb59.png)

P.S.: Sorry for the wall of text 😅 
