### PR TITLE
Set the class name of a function template

### DIFF
--- a/Source/Noesis.Javascript/JavascriptContext.cpp
+++ b/Source/Noesis.Javascript/JavascriptContext.cpp
@@ -292,10 +292,12 @@ void JavascriptContext::SetConstructor(System::String^ name, System::Type^ assoc
     v8::Isolate *isolate = JavascriptContext::GetCurrentIsolate();
     HandleScope handleScope(isolate);
 
+    Local<String> className = ToV8String(isolate, name);
     Handle<FunctionTemplate> functionTemplate = JavascriptInterop::GetFunctionTemplateFromSystemDelegate(constructor);
+    functionTemplate->SetClassName(className);
     JavascriptInterop::InitObjectWrapperTemplate(functionTemplate->InstanceTemplate());
     mTypeToConstructorMapping[associatedType] = System::IntPtr(new Persistent<FunctionTemplate>(isolate, functionTemplate));
-    Local<Context>::New(isolate, *mContext)->Global()->Set(isolate->GetCurrentContext(), ToV8String(isolate, name), functionTemplate->GetFunction());
+    Local<Context>::New(isolate, *mContext)->Global()->Set(isolate->GetCurrentContext(), className, functionTemplate->GetFunction());
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This is used for printing objects created with the function created from the FunctionTemplate as its constructor; e.g in the debug inspector protocol. Otherwise a class `Foo` is printed as `"Object"`. Note that this does not alter the behavior of toString.

Amendment to #71 and #60 