### PR TITLE
Add support for the `Symbol.iterator` function on objects implementing `IEnumerable`

### DIFF
--- a/Source/Noesis.Javascript/JavascriptExternal.h
+++ b/Source/Noesis.Javascript/JavascriptExternal.h
@@ -85,6 +85,8 @@ public:
 
 	Handle<Value> SetProperty(uint32_t iIndex, Handle<Value> iValue);
 
+    Handle<Function> GetIterator();
+
 	////////////////////////////////////////////////////////////
 	// Data members
 	////////////////////////////////////////////////////////////
@@ -98,6 +100,10 @@ private:
 
 	// Owned by JavascriptContext.
 	gcroot<System::Collections::Generic::Dictionary<System::String ^, WrappedMethod> ^> mMethods;
+
+    std::unique_ptr<Persistent<Function>> mIterator;
+    static void IteratorCallback(const v8::FunctionCallbackInfo<Value>& iArgs);
+    static void IteratorNextCallback(const v8::FunctionCallbackInfo<Value>& iArgs);
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Source/Noesis.Javascript/JavascriptInterop.h
+++ b/Source/Noesis.Javascript/JavascriptInterop.h
@@ -114,7 +114,7 @@ private:
 
 	static Handle<Object> WrapFunction(System::Object^ iObject, System::String^ iName);
 
-	static void Getter(Local<String> iName, const PropertyCallbackInfo<Value>& iInfo);
+	static void Getter(Local<Name> iName, const PropertyCallbackInfo<Value>& iInfo);
 
 	static void Setter(Local<String> iName, Local<Value> iValue, const PropertyCallbackInfo<Value>& iInfo);
 


### PR DESCRIPTION
This adds support for the `for-of`-Loop and the spread operator on all custom objects implementing `IEnumerable`. Objects not implementing `IEnumerable` return `undefined` as per spec. The iterator function itself is cached if the enumerable object stays the same; however, this has no impact if the `IEnumerable` is always created anew (e.g. when using `yield return`). The behavior of arrays and `List<T>` is unchanged as they are converted to an array automatically which already supports both features.

@oliverbock What's your opinion on using `auto`? Should I change that to explicit types or can it stay? 😄 