### PR TITLE
Correct date conversions

### DIFF
--- a/Source/Noesis.Javascript/JavascriptInterop.h
+++ b/Source/Noesis.Javascript/JavascriptInterop.h
@@ -90,7 +90,9 @@ private:
 
 	static System::Object^ ConvertObjectFromV8(Handle<Object> iObject, ConvertedObjects &already_converted);
 
-	static System::DateTime^ ConvertDateFromV8(Handle<Value> iValue);
+	static System::DateTime^ ConvertDateFromV8(Handle<Date> iValue);
+
+    static Handle<Date> ConvertDateTimeToV8(System::DateTime^ dateTime);
 
     static System::Text::RegularExpressions::Regex^ ConvertRegexFromV8(Handle<Value> iValue);
 

--- a/Tests/Noesis.Javascript.Tests/DateTest.cs
+++ b/Tests/Noesis.Javascript.Tests/DateTest.cs
@@ -88,5 +88,67 @@ namespace Noesis.Javascript.Tests
             DateTime dateAsReportedByV8 = (DateTime)_context.Run("new Date(2010, 9, 10)");
             dateAsReportedByV8.Should().Be(new DateTime(2010, 10, 10));
         }
+
+        [TestMethod]
+        public void SetDateTimeUtc_DateWhereTimezoneDatabaseIsImportant()
+        {
+            _context.SetParameter("val", new DateTime(1978, 6, 15, 0, 0, 0, DateTimeKind.Utc));
+
+            _context.Run("val.getUTCFullYear()").Should().BeOfType<int>().Which.Should().Be(1978);
+            _context.Run("val.getUTCMonth()").Should().BeOfType<int>().Which.Should().Be(5);
+            _context.Run("val.getUTCDate()").Should().BeOfType<int>().Which.Should().Be(15);
+            _context.Run("val.getUTCHours()").Should().BeOfType<int>().Which.Should().Be(0);
+            _context.Run("val.getUTCMinutes()").Should().BeOfType<int>().Which.Should().Be(0);
+            _context.Run("val.getUTCSeconds()").Should().BeOfType<int>().Which.Should().Be(0);
+        }
+
+        [TestMethod]
+        public void SetDateTimeLocal_DateWhereTimezoneDatabaseIsImportant()
+        {
+            _context.SetParameter("val", new DateTime(1978, 6, 15, 0, 0, 0, DateTimeKind.Local));
+
+            _context.Run("val.getFullYear()").Should().BeOfType<int>().Which.Should().Be(1978);
+            _context.Run("val.getMonth()").Should().BeOfType<int>().Which.Should().Be(5);
+            _context.Run("val.getDate()").Should().BeOfType<int>().Which.Should().Be(15);
+            _context.Run("val.getHours()").Should().BeOfType<int>().Which.Should().Be(0);
+            _context.Run("val.getMinutes()").Should().BeOfType<int>().Which.Should().Be(0);
+            _context.Run("val.getSeconds()").Should().BeOfType<int>().Which.Should().Be(0);
+        }
+
+        [TestMethod]
+        [Ignore]
+        public void SetAndReadDateTimeUtc_DateWhereTimezoneDatabaseIsImportant()
+        {
+            var dateTime = new DateTime(1978, 6, 15, 0, 0, 0, DateTimeKind.Utc);
+            _context.SetParameter("val", dateTime);
+
+            var dateFromV8 = (DateTime) _context.Run("val");
+            dateFromV8.ToUniversalTime().Should().Be(dateTime); // this cannot work without an external dependency like NodaTime
+        }
+
+        [TestMethod]
+        public void SetAndReadDateTimeLocal_DateWhereTimezoneDatabaseIsImportant()
+        {
+            var dateTime = new DateTime(1978, 6, 15, 0, 0, 0, DateTimeKind.Local);
+            _context.SetParameter("val", dateTime);
+
+            _context.Run("val").Should().Be(dateTime);
+        }
+
+        [TestMethod]
+        public void SetAndReadDateTimeUnspecified_DateWhereTimezoneDatabaseIsImportant()
+        {
+            var dateTime = new DateTime(1978, 6, 15);
+            _context.SetParameter("val", dateTime);
+
+            _context.Run("val").Should().Be(dateTime);
+        }
+
+        [TestMethod]
+        public void CreateFixedDateInJavaScript_DateWhereTimezoneDatabaseIsImportant()
+        {
+            DateTime dateAsReportedByV8 = (DateTime) _context.Run("new Date(1978, 5, 15)");
+            dateAsReportedByV8.Should().Be(new DateTime(1978, 6, 15));
+        }
     }
 }


### PR DESCRIPTION
Unfortunately we discovered another nasty edge case regarding the date conversion 👀😞
@oliverbock, @Ablu: Can you please review this very carefully? I only added new tests and did not touch the old ones. AFAIK there is no API to set the current time zone; it is determined by the operation system. So I could not write tests for a specific time zone. Rather I executed the date tests manually after setting my time zone locally. They were green in all the samples I took.

## Problem
We need to be very careful with date conversions because C# **does not use** the [IANA timezone database](https://www.iana.org/time-zones) to determine offsets from UTC / daylight savings time. However, V8 **does use** the IANA timezone database which leads to discrepancies in the date conversion.

## Example
Germany did not observe daylight savings time from 1950-1979 and therefore observed UTC+1 throughout the whole year. However, C# thinks Germany did observe daylight savings time and assumes incorrectly that Germany observed UTC+2 during the summer time.

**V8**
```js
new Date(1978, 5, 15) // "Thu Jun 15 1978 00:00:00 GMT+0100 (Mitteleuropäische Normalzeit)"
```

**C#**
If we get the ticks since `1970-01-01` from V8 to construct a UTC `DateTime` object we get `"1978-06-14 23:00:00"` which is correct. A subsequent call to `.ToLocalTime()` on that date object yields `"1978-06-15 01:00:00"` which is wrong; it should be `"1978-06-15 00:00:00"`!

The same problem exists in the other direction.

We therefore construct date objects directly from the date components we get from V8 and vice versa. I used this approach because I did not want to pull in a dependency on e.g. [NodaTime](https://nodatime.org/). The C++ API currently doesn't offer a correct implementation either.