### PR TITLE
Make sure zero bytes are not discarded when converting strings

### DIFF
--- a/Tests/Noesis.Javascript.Tests/ConvertFromJavascriptTests.cs
+++ b/Tests/Noesis.Javascript.Tests/ConvertFromJavascriptTests.cs
@@ -114,6 +114,22 @@ namespace Noesis.Javascript.Tests
         }
 
         [TestMethod]
+        public void ReadStringWithZeroByte()
+        {
+            _context.Run("var myString = 'a\\0b'");
+
+            _context.GetParameter("myString").Should().BeOfType<string>().Which.Should().Be("a\0b");
+        }
+
+        [TestMethod]
+        public void ReadStringWithMultipleZeroBytes()
+        {
+            _context.Run("var myString = 'a\\0\\0b'");
+
+            _context.GetParameter("myString").Should().BeOfType<string>().Which.Should().Be("a\0\0b");
+        }
+
+        [TestMethod]
         public void ReadArray()
         {
             _context.Run("var myArray = [11,22,33]");

--- a/Tests/Noesis.Javascript.Tests/ConvertToJavascriptTests.cs
+++ b/Tests/Noesis.Javascript.Tests/ConvertToJavascriptTests.cs
@@ -118,7 +118,23 @@ namespace Noesis.Javascript.Tests
 
             _context.Run("val === 'A string from .NET'").Should().BeOfType<bool>().Which.Should().BeTrue();
         }
-        
+
+        [TestMethod]
+        public void SetStringWithZeroByte()
+        {
+            _context.SetParameter("val", "a\0b");
+
+            _context.Run("val === 'a\\0b'").Should().BeOfType<bool>().Which.Should().BeTrue();
+        }
+
+        [TestMethod]
+        public void SetStringWithMultipleZeroBytes()
+        {
+            _context.SetParameter("val", "a\0\0b");
+
+            _context.Run("val === 'a\\0\\0b'").Should().BeOfType<bool>().Which.Should().BeTrue();
+        }
+
         [TestMethod]
         public void SetArray()
         {


### PR DESCRIPTION
Since C++ uses zero byte terminated strings, a cast to wchar_t* discards all characters after a zero byte when used directly to create a C# or V8 string. This is bad for strings containing a zero byte somewhere. We fix that by using a constructor overload taking the actual length of the string as parameter.

**Example:**
```js
const text = 'a\0b'
text
```
would arrive as `"a"` in C# without the fix and vice versa.