### PR TITLE
Remove finalizer of JavascriptFunction

### DIFF
--- a/Source/Noesis.Javascript/JavascriptFunction.cpp
+++ b/Source/Noesis.Javascript/JavascriptFunction.cpp
@@ -39,11 +39,6 @@ JavascriptFunction::~JavascriptFunction()
 	}
 }
 
-JavascriptFunction::!JavascriptFunction()
-{
-    delete this;
-}
-
 System::Object^ JavascriptFunction::Call(... cli::array<System::Object^>^ args)
 {
     if (mFuncHandle == nullptr)

--- a/Source/Noesis.Javascript/JavascriptFunction.h
+++ b/Source/Noesis.Javascript/JavascriptFunction.h
@@ -26,7 +26,6 @@ public ref class JavascriptFunction
 public:
 	JavascriptFunction(v8::Local<v8::Object> iFunction, JavascriptContext^ context);
 	~JavascriptFunction();
-    !JavascriptFunction();
 
 	System::Object^ Call(... cli::array<System::Object^>^ args);
 
@@ -37,7 +36,7 @@ public:
     virtual System::String^ ToString() override;
 
 private:
-	v8::Persistent<v8::Function>* mFuncHandle;
+    v8::Persistent<v8::Function>* mFuncHandle;
 	JavascriptContext^ mContext;
 };
 


### PR DESCRIPTION
The finalizer of `JavascriptFunction` can lead to `System.AccessViolationException`s if an object of this type is disposed manually. This PR removes it.

Resolves #90 