### PR TITLE
Reuse existing `Persistent` object when converting to `Local`

### DIFF
--- a/Source/Noesis.Javascript/JavascriptExternal.h
+++ b/Source/Noesis.Javascript/JavascriptExternal.h
@@ -86,7 +86,7 @@ public:
 
     Local<Function> GetIterator();
 
-    void Wrap(Isolate* isolate, Local<Object> object);
+    Local<Object> ToLocal(Isolate* isolate);
 
 	////////////////////////////////////////////////////////////
 	// Data members
@@ -100,6 +100,8 @@ private:
 	System::Runtime::InteropServices::GCHandle mObjectHandle;
 
 	SetParameterOptions mOptions;
+
+    void InitializePersistent(Isolate* isolate, Local<Object> object);
 
     static void IteratorCallback(const v8::FunctionCallbackInfo<Value>& iArgs);
     static void IteratorNextCallback(const v8::FunctionCallbackInfo<Value>& iArgs);

--- a/Source/Noesis.Javascript/JavascriptInterop.cpp
+++ b/Source/Noesis.Javascript/JavascriptInterop.cpp
@@ -294,19 +294,7 @@ JavascriptInterop::WrapObject(System::Object^ iObject)
     {
         v8::Isolate *isolate = JavascriptContext::GetCurrentIsolate();
         JavascriptExternal *external = context->WrapObject(iObject);
-        if (external->mPersistent.IsEmpty())
-        {
-			Local<FunctionTemplate> templ = context->GetObjectWrapperConstructorTemplate(iObject->GetType());
-			Local<ObjectTemplate> instanceTemplate = templ->InstanceTemplate();
-			Local<Object> object = instanceTemplate->NewInstance(isolate->GetCurrentContext()).ToLocalChecked();
-			external->Wrap(isolate, object);
-
-            return object;
-        }
-        else
-        {
-            return Local<Object>::New(isolate, external->mPersistent);
-        }
+        return external->ToLocal(isolate);
     }
 
 	throw gcnew System::Exception("No context currently active.");


### PR DESCRIPTION
Follow up on #95. This is a) more efficient because we only ever create one `Persistent` per managed object while it is alive and b) prevents a crash when the same managed object is wrapped repeatedly.

Code for Fiddling that crashed before:
```cs
public class Product
{
    public Product()
    {
        Price = new Random().NextDouble();
    }

    public double Price { get; }
}

public class ProductFactory
{
    public ProductFactory()
    {
        Product = new Product();
    }

    public Product Product { get; } // we always return the same object reference here
}

// ...

context.SetParameter("productFactory", new ProductFactory());
context.Run(@"
for (let i = 0; i < 10_000_000; i++) {
    const product = productFactory.Product;
    product.Price;
}
");
```