### PR TITLE
Fix crash in equality operator of `JavascriptFunction`

### DIFF
--- a/Source/Noesis.Javascript/JavascriptFunction.cpp
+++ b/Source/Noesis.Javascript/JavascriptFunction.cpp
@@ -75,9 +75,9 @@ System::Object^ JavascriptFunction::Call(... cli::array<System::Object^>^ args)
 bool JavascriptFunction::operator==(JavascriptFunction^ func1, JavascriptFunction^ func2)
 {
     bool func1_null = ReferenceEquals(func1, nullptr),
-         func2_null = ReferenceEquals(func2, nullptr);
+        func2_null = ReferenceEquals(func2, nullptr);
     if (func1_null != func2_null)
-		return false;
+        return false;
     if (func1_null && func2_null)
         return true;
     if (!func1->IsAlive())
@@ -85,10 +85,17 @@ bool JavascriptFunction::operator==(JavascriptFunction^ func1, JavascriptFunctio
     if (!func2->IsAlive())
         throw gcnew JavascriptException(L"'func2's owning JavascriptContext has been disposed");
 
-	Local<Function> jsFuncPtr1 = func1->mFuncHandle->Get(func1->GetContext()->GetCurrentIsolate());
-	Local<Function> jsFuncPtr2 = func2->mFuncHandle->Get(func2->GetContext()->GetCurrentIsolate());
+    auto context = func1->GetContext();
+    if (func2->GetContext() != context)
+        return false;
 
-	return jsFuncPtr1->Equals(JavascriptContext::GetCurrentIsolate()->GetCurrentContext(), jsFuncPtr2).ToChecked();
+    JavascriptScope scope(context);
+    auto isolate = context->GetCurrentIsolate();
+
+    Local<Function> jsFuncPtr1 = func1->mFuncHandle->Get(isolate);
+    Local<Function> jsFuncPtr2 = func2->mFuncHandle->Get(isolate);
+
+    return jsFuncPtr1->Equals(isolate->GetCurrentContext(), jsFuncPtr2).ToChecked();
 }
 
 bool JavascriptFunction::Equals(JavascriptFunction^ other)

--- a/Source/Noesis.Javascript/JavascriptFunction.cpp
+++ b/Source/Noesis.Javascript/JavascriptFunction.cpp
@@ -91,9 +91,10 @@ bool JavascriptFunction::operator==(JavascriptFunction^ func1, JavascriptFunctio
 
     JavascriptScope scope(context);
     auto isolate = context->GetCurrentIsolate();
+    HandleScope handleScope(isolate);
 
-    Local<Function> jsFuncPtr1 = func1->mFuncHandle->Get(isolate);
-    Local<Function> jsFuncPtr2 = func2->mFuncHandle->Get(isolate);
+    auto jsFuncPtr1 = func1->mFuncHandle->Get(isolate);
+    auto jsFuncPtr2 = func2->mFuncHandle->Get(isolate);
 
     return jsFuncPtr1->Equals(isolate->GetCurrentContext(), jsFuncPtr2).ToChecked();
 }

--- a/Source/Noesis.Javascript/JavascriptFunction.cpp
+++ b/Source/Noesis.Javascript/JavascriptFunction.cpp
@@ -74,12 +74,11 @@ System::Object^ JavascriptFunction::Call(... cli::array<System::Object^>^ args)
 
 bool JavascriptFunction::operator==(JavascriptFunction^ func1, JavascriptFunction^ func2)
 {
-    bool func1_null = ReferenceEquals(func1, nullptr),
-        func2_null = ReferenceEquals(func2, nullptr);
-    if (func1_null != func2_null)
-        return false;
-    if (func1_null && func2_null)
+    if (ReferenceEquals(func1, func2))
         return true;
+    if (ReferenceEquals(func1, nullptr) != ReferenceEquals(func2, nullptr))
+        return false;
+
     if (!func1->IsAlive())
         throw gcnew JavascriptException(L"'func1's owning JavascriptContext has been disposed");
     if (!func2->IsAlive())


### PR DESCRIPTION
We observed a crash in the equality operator of `JavascriptFunction` under highly parallelized load during V8 GC phases. This PR fixes that crash. 

This happened for cases where JS objects with functions were created and passed back to C# creating dictionaries with `JavascriptFunction` objects. Because the GC is involved it only occured during highly parallelized loads with GC pressure. We tried to create a minimal regression test, but couldn't reproduce the crash in simplified cases. If that changes we will send a follow up PR with a regression test.

**Analysis**:
The call of `Contains` in the `GCCallback` function of a `JavascriptExternal` object here
https://github.com/JavascriptNet/Javascript.Net/blob/db13a0856fbc823535d3ab4d381ef5f9a8dc45d3/Source/Noesis.Javascript/JavascriptExternal.cpp#L76-L77
can lead to the comparison of two `JavascriptFunction` objects during the GC phase of V8. When this happens `JavascriptContext::GetCurrentIsolate()->GetCurrentContext()` here
https://github.com/JavascriptNet/Javascript.Net/blob/db13a0856fbc823535d3ab4d381ef5f9a8dc45d3/Source/Noesis.Javascript/JavascriptFunction.cpp#L91
can be `nullptr` leading to the crash. This happens because of a missing `JavascriptScope` inside the operator function leaving the isolate's context `nullptr`. Adding the scope resolves the problem.

Because we can only bind one scope we additionally add a check if the functions are bound to the same `JavascriptContext` object. If they are not we return `false` early, because there's no point in comparing them. This way we only have to deal with one isolate and its corresponding context. A `HandleScope` is added for good measure because we generate `Local<Function>` instances.

Another slight optimization is to return early if both `JavascriptFunction` references are the same. The `ReferenceEquals` method also returns `true` if both are `nullptr` eliminating another check.