### PR TITLE
Remove system-wide mutex in unmanaged initialization

### DIFF
--- a/Source/Noesis.Javascript/JavascriptContext.cpp
+++ b/Source/Noesis.Javascript/JavascriptContext.cpp
@@ -26,7 +26,8 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-#include <atomic>
+#include <mutex>
+#include <shared_mutex>
 #include <msclr\lock.h>
 #include <vcclr.h>
 #include <msclr\marshal.h>
@@ -85,19 +86,26 @@ namespace Noesis { namespace Javascript {
 			strcpy_s(strrchr(icudtl_dat_path, '\\'), 12, "\\icudtl.dat");
 	}
 
-    std::atomic_flag initalized = ATOMIC_FLAG_INIT;
+    bool initialized = false;
+    std::shared_mutex mutex;
+
 	// This code didn't work in managed code, probably due to too-clever smart pointers.
 	void UnmanagedInitialisation()
 	{
-        if (!initalized.test_and_set(std::memory_order_acquire)) {
-            // Get location of DLL so that v8 can use it to find its .dat files.
-            char dll_path[MAX_PATH], icudtl_dat_path[MAX_PATH];
-            GetPathsForInitialisation(dll_path, icudtl_dat_path);
-            v8::V8::InitializeICUDefaultLocation(dll_path, icudtl_dat_path);
-            v8::Platform* platform = v8::platform::NewDefaultPlatform().release();
-            v8::V8::InitializePlatform(platform);
-            v8::V8::Initialize();
-        }
+        if (initialized)
+            return;
+        std::unique_lock<std::shared_mutex> lock(mutex);
+        if (initialized)
+            return;
+
+        // Get location of DLL so that v8 can use it to find its .dat files.
+        char dll_path[MAX_PATH], icudtl_dat_path[MAX_PATH];
+        GetPathsForInitialisation(dll_path, icudtl_dat_path);
+        v8::V8::InitializeICUDefaultLocation(dll_path, icudtl_dat_path);
+        v8::Platform* platform = v8::platform::NewDefaultPlatform().release();
+        v8::V8::InitializePlatform(platform);
+        v8::V8::Initialize();
+        initialized = true;
 	}
 #pragma managed(pop)
 
@@ -112,7 +120,6 @@ v8::Local<v8::String> ToV8String(Isolate* isolate, System::String^ value) {
 
 static JavascriptContext::JavascriptContext()
 {
-    System::Threading::Mutex mutex(true, "FA12B681-E968-4D3A-833D-43B25865BEF1");
     UnmanagedInitialisation();
 }
 


### PR DESCRIPTION
With #53 and #54 the unmanaged initialization of the `v8::platform` object was attempted to be made thread-safe across app domain boundaries. The first PR made it thread-safe in regards to only initializing once, but still had the potential of a race-condition when two app domains are created in parallel and the second app domain already runs JS code while the first app domain still initializes the V8 platform object. This in turn was solved by using a system-wide mutex. But as stated in the PR this strictly is not necessary because we don't cross process boundaries. Furthermore, the implementation never locks/unlocks the mutex and only acquired the handle (this looks like C++ RAII style code which doesn't work here because it's a CLR class), and leads to problems like reported in #91.

This PR addresses that and synchronizes the unmanaged initialization with a `shared_mutex` instead of a system-wide one. The main reason of using a system-wide mutex in #54 was the non-existence of `std::mutex` in C++/CLI (this will probably come in the future). However, `std::shared_mutex` exists and can be used to lock exclusively, too.

Fixes #91