### PR TITLE
Add debugger support

### DIFF
--- a/Source/Noesis.Javascript/JavaScript.Net.vcxproj
+++ b/Source/Noesis.Javascript/JavaScript.Net.vcxproj
@@ -166,6 +166,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="JavascriptContext.h" />
+    <ClInclude Include="JavascriptDebugger.h" />
     <ClInclude Include="JavascriptException.h" />
     <ClInclude Include="JavascriptExternal.h" />
     <ClInclude Include="JavascriptFunction.h" />
@@ -176,6 +177,7 @@
   <ItemGroup>
     <ClCompile Include="AssemblyInfo.cpp" />
     <ClCompile Include="JavascriptContext.cpp" />
+    <ClCompile Include="JavascriptDebugger.cpp" />
     <ClCompile Include="JavascriptException.cpp" />
     <ClCompile Include="JavascriptExternal.cpp" />
     <ClCompile Include="JavascriptFunction.cpp" />

--- a/Source/Noesis.Javascript/JavaScript.Net.vcxproj.filters
+++ b/Source/Noesis.Javascript/JavaScript.Net.vcxproj.filters
@@ -36,6 +36,9 @@
     <ClInclude Include="JavascriptStackFrame.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="JavascriptDebugger.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="AssemblyInfo.cpp">
@@ -57,6 +60,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="JavascriptFunction.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="JavascriptDebugger.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/Source/Noesis.Javascript/JavascriptContext.cpp
+++ b/Source/Noesis.Javascript/JavascriptContext.cpp
@@ -38,6 +38,7 @@
 #include "JavascriptContext.h"
 
 #include "SystemInterop.h"
+#include "JavascriptDebugger.h"
 #include "JavascriptException.h"
 #include "JavascriptExternal.h"
 #include "JavascriptFunction.h"
@@ -172,15 +173,27 @@ JavascriptContext::JavascriptContext()
 	HandleScope scope(isolate);
 	mContext = new Persistent<Context>(isolate, Context::New(isolate));
     terminateRuns = false;
+    mDebugger = nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 JavascriptContext::~JavascriptContext()
 {
+    // Guard against double-Dispose: isolate is nulled at the end so a second call is a no-op.
+    if (isolate == nullptr) return;
+
 	{
 		v8::Locker v8ThreadLock(isolate);
 		v8::Isolate::Scope isolate_scope(isolate);
+
+		// Notify attached debugger before V8 cleanup so it can disconnect cleanly.
+		if (mDebugger != nullptr)
+		{
+			mDebugger->OnContextDisposing();
+			mDebugger = nullptr;
+		}
+
 		for each (WrappedJavascriptExternal wrapped in mExternals->Values)
 			delete wrapped.Pointer;
         // Clean up JavascriptFunction wrappers
@@ -216,7 +229,10 @@ JavascriptContext::~JavascriptContext()
         delete mTypeToConstructorMapping;
 	}
 	if (isolate != NULL)
+	{
 		isolate->Dispose();
+		isolate = nullptr;  // Null so double-Dispose is safe (guard check above).
+	}
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -350,8 +366,14 @@ JavascriptContext::Run(System::String^ iScript)
 	JavascriptScope scope(this);
 	//SetStackLimit();
 	HandleScope handleScope(isolate);
+
+	// Flush any queued debugger commands (e.g., Debugger.enable, setBreakpoint)
+	// before executing so they take effect for this run.
+	if (mDebugger != nullptr)
+		mDebugger->ProcessPendingCommands();
+
 	MaybeLocal<Value> ret;
-	
+
 	Local<Script> compiledScript = CompileScript(isolate, script);
 
 	{
@@ -361,7 +383,7 @@ JavascriptContext::Run(System::String^ iScript)
 		if (ret.IsEmpty())
 			throw gcnew JavascriptException(tryCatch);
 	}
-	
+
 	return JavascriptInterop::ConvertFromV8(ret.ToLocalChecked());
 }
 
@@ -383,7 +405,12 @@ JavascriptContext::Run(System::String^ iScript, System::String^ iScriptResourceN
 	JavascriptScope scope(this);
 	//SetStackLimit();
 	HandleScope handleScope(isolate);
-	MaybeLocal<Value> ret;	
+
+	// Flush any queued debugger commands before executing.
+	if (mDebugger != nullptr)
+		mDebugger->ProcessPendingCommands();
+
+	MaybeLocal<Value> ret;
 
 	Local<Script> compiledScript = CompileScript(isolate, script, scriptResourceName);
 	

--- a/Source/Noesis.Javascript/JavascriptContext.h
+++ b/Source/Noesis.Javascript/JavascriptContext.h
@@ -48,6 +48,7 @@ using namespace std;
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
 class JavascriptExternal;
+ref class JavascriptDebugger;  // Forward declaration (defined in JavascriptDebugger.h)
 
 [System::Flags]
 public enum class SetParameterOptions : int
@@ -237,10 +238,14 @@ internal:
 	//void SetStackLimit();
 
 	static JavascriptContext^ GetCurrent();
-	
+
 	static v8::Isolate *GetCurrentIsolate();
 
 	Local<v8::Object> GetGlobal();
+
+    // Accessors for debugger integration
+    v8::Isolate* GetIsolate() { return isolate; }
+    v8::Persistent<v8::Context>* GetContextPersistent() { return mContext; }
 
     v8::Locker *Enter([System::Runtime::InteropServices::Out] JavascriptContext^% old_context);
 
@@ -271,6 +276,9 @@ internal:
     System::Collections::Generic::Dictionary<int, WrappedJavascriptFunction>^ mFunctions;
 
     System::Collections::Generic::Dictionary<System::String^, WrappedMethod>^ mMethods;
+
+    // Attached debugger, if any. Set by JavascriptDebugger constructor.
+    JavascriptDebugger^ mDebugger;
 protected:
 	// By entering an isolate before using a context, we can have multiple
 	// contexts used simultaneously in different threads.

--- a/Source/Noesis.Javascript/JavascriptDebugger.cpp
+++ b/Source/Noesis.Javascript/JavascriptDebugger.cpp
@@ -1,0 +1,455 @@
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// File: JavascriptDebugger.cpp
+//
+// Copyright 2010 Noesis Innovation Inc. All rights reserved.
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+//       copyright notice, this list of conditions and the following
+//       disclaimer in the documentation and/or other materials provided
+//       with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#include <v8-inspector.h>
+#include <vcclr.h>
+#include <string>
+#include <deque>
+#include <mutex>
+#include <condition_variable>
+#include <atomic>
+#include <memory>
+
+#include "JavascriptDebugger.h"
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace Noesis { namespace Javascript {
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// String conversion helpers
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+static System::String^ StringViewToManagedString(const v8_inspector::StringView& view)
+{
+    if (view.length() == 0)
+        return System::String::Empty;
+
+    if (view.is8Bit())
+    {
+        // V8 inspector 8-bit strings are UTF-8 encoded (CDP JSON is ASCII-safe)
+        cli::array<System::Byte>^ bytes = gcnew cli::array<System::Byte>((int)view.length());
+        pin_ptr<System::Byte> pinned = &bytes[0];
+        memcpy(pinned, view.characters8(), view.length());
+        return System::Text::Encoding::UTF8->GetString(bytes);
+    }
+    else
+    {
+        // 16-bit UTF-16
+        return gcnew System::String((const wchar_t*)view.characters16(), 0, (int)view.length());
+    }
+}
+
+static std::string ManagedStringToUtf8(System::String^ str)
+{
+    cli::array<System::Byte>^ bytes = System::Text::Encoding::UTF8->GetBytes(str);
+    std::string result(bytes->Length, '\0');
+    if (bytes->Length > 0)
+    {
+        pin_ptr<System::Byte> pinned = &bytes[0];
+        memcpy(result.data(), pinned, bytes->Length);
+    }
+    return result;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// InspectorImpl
+//
+// Native struct that implements both V8InspectorClient (V8 -> us callbacks) and
+// V8Inspector::Channel (V8 -> us protocol messages).
+//
+// Threading model:
+//   - V8 callbacks (runMessageLoopOnPause, sendResponse, sendNotification) are
+//     always called on the V8 thread (the thread holding the V8 lock).
+//   - EnqueueCommand() is thread-safe and may be called from any thread.
+//   - ProcessPending() must be called on the V8 thread.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+struct InspectorImpl : v8_inspector::V8InspectorClient, v8_inspector::V8Inspector::Channel
+{
+    static const int kContextGroupId = 1;
+
+    v8::Isolate* isolate;
+    v8::Persistent<v8::Context>* contextPersistent;
+    std::unique_ptr<v8_inspector::V8Inspector> inspector;
+    std::unique_ptr<v8_inspector::V8InspectorSession> session;
+
+    // Command queue: commands enqueued from any thread, dispatched on V8 thread.
+    std::mutex queueMutex;
+    std::condition_variable cv;
+    std::deque<std::string> pendingCommands;
+    std::atomic<bool> paused;
+    std::atomic<bool> waitingForDebugger;
+    std::atomic<bool> disconnecting;
+
+    // GC root keeping the managed JavascriptDebugger alive while this struct exists.
+    gcroot<JavascriptDebugger^> managedDebugger;
+
+    InspectorImpl(v8::Isolate* iso, v8::Persistent<v8::Context>* ctx, bool waitForDebugger)
+        : isolate(iso)
+        , contextPersistent(ctx)
+        , paused(waitForDebugger)
+        , waitingForDebugger(waitForDebugger)
+        , disconnecting(false)
+    {
+        inspector = v8_inspector::V8Inspector::create(isolate, this);
+    }
+
+    ~InspectorImpl()
+    {
+        // If still connected, perform a minimal disconnect without V8 access
+        // (safe path when called from JavascriptDebugger destructor after
+        // OnContextDisposing has already done V8 cleanup).
+        SignalStop(true);
+    }
+
+    // Connect the inspector session. Must be called with the V8 lock held.
+    void Connect()
+    {
+        v8::HandleScope scope(isolate);
+
+        v8_inspector::StringView emptyState;
+        session = inspector->connect(
+            kContextGroupId,
+            this,
+            emptyState,
+            v8_inspector::V8Inspector::kFullyTrusted,
+            waitingForDebugger ? v8_inspector::V8Inspector::kWaitingForDebugger : v8_inspector::V8Inspector::kNotWaitingForDebugger);
+
+        v8::Local<v8::Context> ctx = contextPersistent->Get(isolate);
+        const uint8_t name[] = "JavaScript.Net";
+        v8_inspector::StringView contextName(name, sizeof(name) - 1);
+        inspector->contextCreated(v8_inspector::V8ContextInfo(ctx, kContextGroupId, contextName));
+    }
+
+    // Disconnect the inspector session. Must be called with the V8 lock held.
+    // Resets both session and inspector to null while the lock is held, so
+    // their V8 destructors never run without the lock (e.g. from ~InspectorImpl
+    // via delete mImpl after the JavascriptScope has already released the lock).
+    void Disconnect()
+    {
+        if (!inspector) return;  // Already disconnected
+
+        // Unblock any thread waiting in runMessageLoopOnPause.
+        SignalStop(true);
+
+        if (session)
+        {
+            session->stop();
+            session.reset();
+        }
+
+        v8::HandleScope scope(isolate);
+        v8::Local<v8::Context> ctx = contextPersistent->Get(isolate);
+        inspector->contextDestroyed(ctx);
+        inspector.reset();  // Must be reset here, with the V8 lock held.
+                            // The unique_ptr destructor in ~InspectorImpl would
+                            // otherwise call ~V8Inspector() without the lock.
+    }
+
+    // Signal the pause loop to exit without V8 operations.
+    // Pass isDisconnecting=true when tearing down so that runMessageLoopOnPause
+    // will not re-enter after returning. Use the default (false) for transient
+    // unblocks such as runIfWaitingForDebugger.
+    // Safe to call without the V8 lock.
+    void SignalStop(bool isDisconnecting = false)
+    {
+        std::lock_guard<std::mutex> lock(queueMutex);
+        if (isDisconnecting) disconnecting = true;
+        paused = false;
+        waitingForDebugger = false;
+        cv.notify_all();
+    }
+
+    bool IsConnected() const { return session != nullptr; }
+
+    bool IsPaused() const { return paused; }
+
+    // Enqueue a command for dispatch on the V8 thread. Thread-safe.
+    void EnqueueCommand(std::string cmd)
+    {
+        std::lock_guard<std::mutex> lock(queueMutex);
+        pendingCommands.push_back(std::move(cmd));
+        cv.notify_one();
+    }
+
+    // Dispatch all currently queued commands. Must be called on the V8 thread.
+    void ProcessPending()
+    {
+        if (!session) return;
+
+        // Flush any already-queued commands first (e.g. pre-queued before Run()).
+        DispatchQueued();
+
+        // If waiting for the debugger, block here on the V8 thread processing
+        // incoming commands until Runtime.runIfWaitingForDebugger is received.
+        // This mirrors how Chrome/Node.js implement --inspect-brk: the host
+        // blocks before any script runs, letting the client connect, send
+        // Debugger.enable / setBreakpoint, etc., then release via
+        // Runtime.runIfWaitingForDebugger.
+        while (waitingForDebugger)
+        {
+            std::unique_lock<std::mutex> lock(queueMutex);
+            cv.wait(lock, [this] {
+                return !pendingCommands.empty() || !waitingForDebugger.load();
+            });
+
+            if (!waitingForDebugger) break;
+
+            std::string cmd = std::move(pendingCommands.front());
+            pendingCommands.pop_front();
+            lock.unlock();
+
+            if (session)
+            {
+                v8_inspector::StringView sv(
+                    reinterpret_cast<const uint8_t*>(cmd.data()), cmd.size());
+                session->dispatchProtocolMessage(sv);
+            }
+        }
+    }
+
+    // Dispatch all currently queued commands without blocking.
+    void DispatchQueued()
+    {
+        while (true)
+        {
+            std::string cmd;
+            {
+                std::lock_guard<std::mutex> lock(queueMutex);
+                if (pendingCommands.empty()) break;
+                cmd = std::move(pendingCommands.front());
+                pendingCommands.pop_front();
+            }
+            v8_inspector::StringView sv(
+                reinterpret_cast<const uint8_t*>(cmd.data()), cmd.size());
+            session->dispatchProtocolMessage(sv);
+        }
+    }
+
+    ////////////////////////////////////////////////////////////
+    // V8InspectorClient interface
+    ////////////////////////////////////////////////////////////
+
+    // Called by V8 when execution pauses (breakpoint, debugger statement, step).
+    // Blocks the V8 thread until a resume/step command is dispatched.
+    void runMessageLoopOnPause(int contextGroupId) override
+    {
+        // Guard against the race where SignalStop() (from Dispose()) fires before
+        // this method is entered. Setting paused=true only under the lock ensures
+        // that either SignalStop() already set disconnecting=true (and we see it
+        // here and bail), or SignalStop() will see paused=true and notify the CV.
+        {
+            std::lock_guard<std::mutex> lock(queueMutex);
+            if (disconnecting) return;
+            paused = true;
+        }
+
+        while (true)
+        {
+            std::unique_lock<std::mutex> lock(queueMutex);
+            cv.wait(lock, [this] {
+                return !pendingCommands.empty() || !paused.load() || disconnecting.load();
+            });
+
+            if (!paused || disconnecting) break;
+
+            std::string cmd = std::move(pendingCommands.front());
+            pendingCommands.pop_front();
+            lock.unlock();
+
+            // Dispatch on V8 thread (safe: we hold the V8 lock throughout).
+            if (session)
+            {
+                v8_inspector::StringView sv(
+                    reinterpret_cast<const uint8_t*>(cmd.data()), cmd.size());
+                session->dispatchProtocolMessage(sv);
+            }
+        }
+
+        paused = false;
+    }
+
+    // Called by V8 when Runtime.runIfWaitingForDebugger is dispatched.
+    // Only invoked when the session was connected with kWaitingForDebugger.
+    void runIfWaitingForDebugger(int contextGroupId) override
+    {
+        waitingForDebugger = false;
+        SignalStop();
+    }
+
+    // Called by V8 when execution should resume from a pause.
+    void quitMessageLoopOnPause() override
+    {
+        SignalStop();
+    }
+
+    // Called by V8 to get the default context for a group.
+    v8::Local<v8::Context> ensureDefaultContextInGroup(int contextGroupId) override
+    {
+        return contextPersistent->Get(isolate);
+    }
+
+    ////////////////////////////////////////////////////////////
+    // V8Inspector::Channel interface
+    ////////////////////////////////////////////////////////////
+
+    // Called by V8 to send a CDP response to a command we dispatched.
+    void sendResponse(int callId, std::unique_ptr<v8_inspector::StringBuffer> message) override
+    {
+        FireMessage(message->string());
+    }
+
+    // Called by V8 to send a CDP notification/event (e.g., "Debugger.paused").
+    void sendNotification(std::unique_ptr<v8_inspector::StringBuffer> message) override
+    {
+        FireMessage(message->string());
+    }
+
+    void flushProtocolNotifications() override {}
+
+private:
+    void FireMessage(const v8_inspector::StringView& view)
+    {
+        System::String^ msg = StringViewToManagedString(view);
+        managedDebugger->OnMessageReceived(msg);
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// JavascriptDebugger
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+JavascriptDebugger::JavascriptDebugger(JavascriptContext^ context, bool waitForDebugger)
+{
+    if (context == nullptr)
+        throw gcnew System::ArgumentNullException("context");
+    if (context->IsDisposed())
+        throw gcnew System::ObjectDisposedException("context");
+
+    mContext = context;
+    mDisposed = false;
+
+    // Construct with native-only parameters (managed types are forbidden in the
+    // InspectorImpl constructor due to V8_EXPORT base class constraints), then
+    // set the managed back-reference from this managed constructor.
+    mImpl = new InspectorImpl(context->GetIsolate(), context->GetContextPersistent(), waitForDebugger);
+    mImpl->managedDebugger = this;
+
+    // Connect while holding the V8 lock so the inspector sees the context.
+    JavascriptScope scope(context);
+    mImpl->Connect();
+
+    // Register with the context so Run() will flush pending commands.
+    context->mDebugger = this;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+JavascriptDebugger::~JavascriptDebugger()
+{
+    if (mDisposed) return;
+    mDisposed = true;
+
+    if (mContext != nullptr && !mContext->IsDisposed())
+    {
+        // Normal disposal: context is still alive, do V8-aware cleanup.
+        mContext->mDebugger = nullptr;
+
+        // Signal before acquiring the V8 lock. If the V8 thread is blocked in
+        // runMessageLoopOnPause (holding the V8 lock), this unblocks it so it
+        // can release the lock — otherwise acquiring JavascriptScope would deadlock.
+        mImpl->SignalStop(true);
+
+        JavascriptScope scope(mContext);
+        mImpl->Disconnect();
+    }
+    // else: OnContextDisposing() was already called by the context destructor,
+    // which performed V8 cleanup. mImpl->session is already null.
+
+    delete mImpl;
+    mImpl = nullptr;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+void JavascriptDebugger::SendCommand(System::String^ jsonMessage)
+{
+    if (mDisposed)
+        throw gcnew System::ObjectDisposedException("JavascriptDebugger");
+    if (jsonMessage == nullptr)
+        throw gcnew System::ArgumentNullException("jsonMessage");
+    if (!mImpl->IsConnected())
+        throw gcnew System::InvalidOperationException("Debugger is not connected.");
+
+    mImpl->EnqueueCommand(ManagedStringToUtf8(jsonMessage));
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+bool JavascriptDebugger::IsConnected::get()
+{
+    return !mDisposed && mImpl != nullptr && mImpl->IsConnected();
+}
+
+bool JavascriptDebugger::IsPaused::get()
+{
+    return !mDisposed && mImpl != nullptr && mImpl->IsPaused();
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+void JavascriptDebugger::OnMessageReceived(System::String^ message)
+{
+    MessageReceived(this, gcnew DebuggerMessageEventArgs(message));
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+void JavascriptDebugger::ProcessPendingCommands()
+{
+    if (mImpl != nullptr && mImpl->IsConnected())
+        mImpl->ProcessPending();
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+void JavascriptDebugger::OnContextDisposing()
+{
+    // Called from JavascriptContext::~JavascriptContext() with the V8 lock held.
+    // Perform V8-aware cleanup before the isolate is disposed.
+    if (mImpl != nullptr)
+        mImpl->Disconnect();
+    mContext = nullptr;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+} } // namespace Noesis::Javascript
+
+////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Source/Noesis.Javascript/JavascriptDebugger.cpp
+++ b/Source/Noesis.Javascript/JavascriptDebugger.cpp
@@ -53,10 +53,7 @@ static System::String^ StringViewToManagedString(const v8_inspector::StringView&
     if (view.is8Bit())
     {
         // V8 inspector 8-bit strings are UTF-8 encoded (CDP JSON is ASCII-safe)
-        cli::array<System::Byte>^ bytes = gcnew cli::array<System::Byte>((int)view.length());
-        pin_ptr<System::Byte> pinned = &bytes[0];
-        memcpy(pinned, view.characters8(), view.length());
-        return System::Text::Encoding::UTF8->GetString(bytes);
+        return System::Text::Encoding::UTF8->GetString((System::Byte*)view.characters8(), (int)view.length());
     }
     else
     {
@@ -216,10 +213,10 @@ struct InspectorImpl : v8_inspector::V8InspectorClient, v8_inspector::V8Inspecto
         {
             std::unique_lock<std::mutex> lock(queueMutex);
             cv.wait(lock, [this] {
-                return !pendingCommands.empty() || !waitingForDebugger.load();
+                return !pendingCommands.empty() || !waitingForDebugger.load() || disconnecting.load();
             });
 
-            if (!waitingForDebugger) break;
+            if (!waitingForDebugger || disconnecting) break;
 
             std::string cmd = std::move(pendingCommands.front());
             pendingCommands.pop_front();
@@ -336,6 +333,7 @@ struct InspectorImpl : v8_inspector::V8InspectorClient, v8_inspector::V8Inspecto
 private:
     void FireMessage(const v8_inspector::StringView& view)
     {
+        if (disconnecting) return;
         System::String^ msg = StringViewToManagedString(view);
         managedDebugger->OnMessageReceived(msg);
     }

--- a/Source/Noesis.Javascript/JavascriptDebugger.h
+++ b/Source/Noesis.Javascript/JavascriptDebugger.h
@@ -1,0 +1,167 @@
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// File: JavascriptDebugger.h
+//
+// Copyright 2010 Noesis Innovation Inc. All rights reserved.
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+//       notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+//       copyright notice, this list of conditions and the following
+//       disclaimer in the documentation and/or other materials provided
+//       with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#include "JavascriptContext.h"
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+namespace Noesis { namespace Javascript {
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// Forward declaration of native implementation struct (defined in JavascriptDebugger.cpp)
+struct InspectorImpl;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// DebuggerMessageEventArgs
+//
+// Event arguments for messages received from the V8 inspector.
+// The Message property contains the raw Chrome DevTools Protocol (CDP) JSON string.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+public ref class DebuggerMessageEventArgs : System::EventArgs
+{
+public:
+    property System::String^ Message;
+
+    DebuggerMessageEventArgs(System::String^ message)
+    {
+        Message = message;
+    }
+};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// JavascriptDebugger
+//
+// Attaches a V8 Inspector session to a JavascriptContext, providing access to the
+// Chrome DevTools Protocol (CDP) for debugging JavaScript execution.
+//
+// Usage:
+//   using var context = new JavascriptContext();
+//   using var debugger = new JavascriptDebugger(context);
+//   debugger.MessageReceived += (s, e) => Console.WriteLine(e.Message);
+//
+//   // Queue setup commands before running (processed at start of Run())
+//   debugger.SendCommand("{\"id\":1,\"method\":\"Debugger.enable\"}");
+//   debugger.SendCommand("{\"id\":2,\"method\":\"Debugger.setBreakpointByUrl\",...}");
+//
+//   context.Run(script);
+//   // When paused at a breakpoint, MessageReceived fires with "Debugger.paused"
+//   // Send resume/step commands from any thread via SendCommand()
+//
+// Threading:
+//   - SendCommand() is thread-safe and may be called from any thread.
+//   - Commands sent before Run() are queued and dispatched at the start of Run().
+//   - Commands sent while paused at a breakpoint are dispatched on the V8 thread
+//     from within the debugger's pause message loop.
+//   - MessageReceived events are fired on the V8 thread (the thread calling Run()).
+//
+// Lifetime:
+//   - The debugger must be disposed before the context, or the context disposes
+//     the debugger automatically via its own destructor.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+public ref class JavascriptDebugger : System::IDisposable
+{
+    ////////////////////////////////////////////////////////////
+    // Constructor/Destructor
+    ////////////////////////////////////////////////////////////
+public:
+    /// <summary>
+    /// Creates and connects a V8 Inspector session to the given context.
+    /// Must be called before context.Run() to enable debugging for subsequent runs.
+    /// </summary>
+    JavascriptDebugger(JavascriptContext^ context, bool waitForDebugger);
+
+    ~JavascriptDebugger();
+
+    ////////////////////////////////////////////////////////////
+    // Public API
+    ////////////////////////////////////////////////////////////
+public:
+    /// <summary>
+    /// Fired when the V8 inspector sends a CDP response or notification.
+    /// The Message property contains the raw JSON string.
+    /// This event is fired on the V8 thread (the thread calling Run()).
+    /// </summary>
+    event System::EventHandler<DebuggerMessageEventArgs^>^ MessageReceived;
+
+    /// <summary>
+    /// Sends a Chrome DevTools Protocol (CDP) command to the V8 inspector.
+    /// Thread-safe: may be called from any thread.
+    ///
+    /// Commands sent before Run() is called are queued and dispatched at the
+    /// start of the next Run() call, before script execution begins.
+    ///
+    /// Commands sent from a background thread while the script is paused at a
+    /// breakpoint are dispatched from within the pause message loop on the V8 thread.
+    /// </summary>
+    void SendCommand(System::String^ jsonMessage);
+
+    /// <summary>
+    /// Whether the debugger session is currently active.
+    /// </summary>
+    property bool IsConnected { bool get(); }
+
+    /// <summary>
+    /// Whether the debuger session is currently paused.
+    /// </summary>
+    property bool IsPaused { bool get(); }
+
+    ////////////////////////////////////////////////////////////
+    // Internal methods (used by JavascriptContext and InspectorImpl)
+    ////////////////////////////////////////////////////////////
+internal:
+    /// Called by InspectorImpl to deliver CDP messages from V8 to managed code.
+    void OnMessageReceived(System::String^ message);
+
+    /// Dispatches all currently queued commands on the V8 thread.
+    /// Called by JavascriptContext::Run() before executing a script.
+    /// Must be called while holding the V8 lock.
+    void ProcessPendingCommands();
+
+    /// Called by JavascriptContext::~JavascriptContext() before V8 cleanup.
+    /// Performs V8-aware disconnect while the V8 lock is still held.
+    void OnContextDisposing();
+
+    ////////////////////////////////////////////////////////////
+    // Data members
+    ////////////////////////////////////////////////////////////
+private:
+    InspectorImpl* mImpl;
+    JavascriptContext^ mContext;
+    bool mDisposed;
+};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+} } // namespace Noesis::Javascript
+
+////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Tests/Noesis.Javascript.Tests/DebuggerTests.cs
+++ b/Tests/Noesis.Javascript.Tests/DebuggerTests.cs
@@ -1,0 +1,279 @@
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Noesis.Javascript.Tests
+{
+    [TestClass]
+    public class DebuggerTests
+    {
+        private JavascriptContext _context = null!;
+
+        [TestInitialize]
+        public void SetUp()
+        {
+            _context = new JavascriptContext();
+        }
+
+        [TestCleanup]
+        public void TearDown()
+        {
+            _context.Dispose();
+        }
+
+        [TestMethod]
+        public void CanCreateAndDisposeDebugger()
+        {
+            using var debugger = new JavascriptDebugger(_context, false);
+            debugger.IsConnected.Should().BeTrue();
+        }
+
+        [TestMethod]
+        public void DisposingDebuggerBeforeContextIsClean()
+        {
+            var debugger = new JavascriptDebugger(_context, false);
+            debugger.Dispose();
+            debugger.IsConnected.Should().BeFalse();
+
+            // Context should still work after debugger is disposed.
+            _context.Run("1 + 1").Should().Be(2);
+        }
+
+        [TestMethod]
+        public void DisposingContextBeforeDebuggerIsClean()
+        {
+            var debugger = new JavascriptDebugger(_context, false);
+            // Dispose context first - it should notify the debugger.
+            _context.Dispose();
+            // Debugger should now report not connected (context gone).
+            debugger.IsConnected.Should().BeFalse();
+            // Disposing the debugger afterwards should not throw.
+            Action dispose = () => debugger.Dispose();
+            dispose.Should().NotThrow();
+        }
+
+        [TestMethod]
+        public void ReceivesResponseToDebuggerEnable()
+        {
+            using var debugger = new JavascriptDebugger(_context, false);
+
+            var messages = new List<string>();
+            debugger.MessageReceived += (_, e) => messages.Add(e.Message);
+
+            // Queue Debugger.enable before Run(); it is dispatched at the start of Run().
+            debugger.SendCommand("{\"id\":1,\"method\":\"Debugger.enable\"}");
+            _context.Run("1 + 1");
+
+            // Should have received a response with matching id.
+            messages.Should().Contain(m => m.Contains("\"id\":1"));
+        }
+
+        [TestMethod]
+        public async Task WaitsForDebugger()
+        {
+            using var debugger = new JavascriptDebugger(_context, true);
+            var messages = new List<string>();
+            debugger.MessageReceived += (_, e) => messages.Add(e.Message);
+
+            var task = Task.Run(() => _context.Run("1 + 1;"));
+            Thread.Sleep(100);
+            debugger.IsPaused.Should().BeTrue("debugger should be paused waiting for runIfWaitingForDebugger");
+            task.IsCompleted.Should().BeFalse("script should be waiting for debugger to attach");
+
+            debugger.SendCommand("{\"id\":1,\"method\":\"Debugger.enable\"}");
+            debugger.SendCommand("{\"id\":2,\"method\":\"Runtime.runIfWaitingForDebugger\"}");
+
+            await task;
+
+            debugger.IsPaused.Should().BeFalse("debugger should NOT be paused, run has completed");
+        }
+
+        [TestMethod]
+        public void PausesAtDebuggerStatement()
+        {
+            using var debugger = new JavascriptDebugger(_context, false);
+
+            bool pausedEventReceived = false;
+            debugger.MessageReceived += (_, e) =>
+            {
+                var json = JsonDocument.Parse(e.Message);
+                if (json.RootElement.TryGetProperty("method", out var method) &&
+                    method.GetString() == "Debugger.paused")
+                {
+                    pausedEventReceived = true;
+                    // Send resume to unblock execution.
+                    debugger.SendCommand("{\"id\":2,\"method\":\"Debugger.resume\"}");
+                }
+            };
+
+            debugger.SendCommand("{\"id\":1,\"method\":\"Debugger.enable\"}");
+            _context.Run("debugger; 1 + 1;");
+
+            pausedEventReceived.Should().BeTrue("a 'debugger' statement should pause execution");
+        }
+
+        [TestMethod]
+        public void PausedEventContainsCallFrames()
+        {
+            using var debugger = new JavascriptDebugger(_context, false);
+
+            string? pausedJson = null;
+            debugger.MessageReceived += (_, e) =>
+            {
+                var json = JsonDocument.Parse(e.Message);
+                if (json.RootElement.TryGetProperty("method", out var method) &&
+                    method.GetString() == "Debugger.paused")
+                {
+                    pausedJson = e.Message;
+                    debugger.SendCommand("{\"id\":2,\"method\":\"Debugger.resume\"}");
+                }
+            };
+
+            debugger.SendCommand("{\"id\":1,\"method\":\"Debugger.enable\"}");
+            _context.Run("debugger;", "test-script.js");
+
+            pausedJson.Should().NotBeNull();
+            var doc = JsonDocument.Parse(pausedJson!);
+            doc.RootElement
+               .GetProperty("params")
+               .GetProperty("callFrames")
+               .GetArrayLength()
+               .Should().BeGreaterThan(0);
+        }
+
+        [TestMethod]
+        public void ResumeAfterPauseAllowsScriptToComplete()
+        {
+            using var debugger = new JavascriptDebugger(_context, false);
+
+            int resumeCount = 0;
+            debugger.MessageReceived += (_, e) =>
+            {
+                var json = JsonDocument.Parse(e.Message);
+                if (json.RootElement.TryGetProperty("method", out var method) &&
+                    method.GetString() == "Debugger.paused")
+                {
+                    resumeCount++;
+                    debugger.SendCommand($"{{\"id\":{resumeCount + 10},\"method\":\"Debugger.resume\"}}");
+                }
+            };
+
+            debugger.SendCommand("{\"id\":1,\"method\":\"Debugger.enable\"}");
+
+            // Script has two debugger statements; both should pause and resume.
+            var result = _context.Run("debugger; debugger; 42;");
+
+            resumeCount.Should().Be(2);
+            result.Should().Be(42);
+        }
+
+        [TestMethod]
+        public void SendCommandFromBackgroundThreadWhilePaused()
+        {
+            using var debugger = new JavascriptDebugger(_context, false);
+
+            bool pausedEventReceived = false;
+            debugger.MessageReceived += (_, e) =>
+            {
+                var json = JsonDocument.Parse(e.Message);
+                if (json.RootElement.TryGetProperty("method", out var method) &&
+                    method.GetString() == "Debugger.paused")
+                {
+                    pausedEventReceived = true;
+                    // Send resume from a background thread.
+                    Task.Run(() =>
+                    {
+                        Thread.Sleep(10); // Small delay to test async path.
+                        debugger.SendCommand("{\"id\":2,\"method\":\"Debugger.resume\"}");
+                    });
+                }
+            };
+
+            debugger.SendCommand("{\"id\":1,\"method\":\"Debugger.enable\"}");
+            _context.Run("debugger;");
+
+            pausedEventReceived.Should().BeTrue();
+        }
+
+        [TestMethod]
+        public async Task DisposingWhilePausedDoesNotDeadlock()
+        {
+            // Regression test: disposing the debugger from a non-V8 thread while
+            // V8 is blocked in runMessageLoopOnPause previously deadlocked because
+            // the destructor tried to acquire the V8 lock before signalling the
+            // condition variable that unblocks the V8 thread.
+            var debugger = new JavascriptDebugger(_context, false);
+
+            // RunContinuationsAsynchronously prevents the await continuation from
+            // running inline on the V8 thread (which fires this event), ensuring
+            // Dispose() is always called from a separate thread.
+            var pausedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            debugger.MessageReceived += (_, e) =>
+            {
+                var json = JsonDocument.Parse(e.Message);
+                if (json.RootElement.TryGetProperty("method", out var method) &&
+                    method.GetString() == "Debugger.paused")
+                {
+                    pausedTcs.TrySetResult();
+                }
+            };
+
+            debugger.SendCommand("{\"id\":1,\"method\":\"Debugger.enable\"}");
+
+            // Run script on a background thread; it will pause at the debugger statement.
+            var runTask = Task.Run(() => _context.Run("debugger; 1 + 1;"));
+
+            // Wait until V8 has sent Debugger.paused, then give it a moment to
+            // enter runMessageLoopOnPause (notification fires just before the call).
+            await pausedTcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            Thread.Sleep(50);
+            debugger.IsPaused.Should().BeTrue();
+
+            // Dispose from this thread while V8 is paused — must not deadlock.
+            debugger.Dispose();
+
+            // The background Run() should complete now that the pause was broken.
+            await runTask.WaitAsync(TimeSpan.FromSeconds(5));
+            debugger.IsConnected.Should().BeFalse();
+        }
+
+        [TestMethod]
+        public void SendCommandThrowsWhenDisposed()
+        {
+            var debugger = new JavascriptDebugger(_context, false);
+            debugger.Dispose();
+
+            Action send = () => debugger.SendCommand("{\"id\":1,\"method\":\"Debugger.enable\"}");
+            send.Should().Throw<ObjectDisposedException>();
+        }
+
+        [TestMethod]
+        public void MultipleRunsWithSameDebugger()
+        {
+            using var debugger = new JavascriptDebugger(_context, false);
+
+            int pauseCount = 0;
+            debugger.MessageReceived += (_, e) =>
+            {
+                var json = JsonDocument.Parse(e.Message);
+                if (json.RootElement.TryGetProperty("method", out var method) &&
+                    method.GetString() == "Debugger.paused")
+                {
+                    pauseCount++;
+                    debugger.SendCommand($"{{\"id\":{pauseCount + 10},\"method\":\"Debugger.resume\"}}");
+                }
+            };
+
+            debugger.SendCommand("{\"id\":1,\"method\":\"Debugger.enable\"}");
+
+            _context.Run("debugger;");
+            _context.Run("debugger;");
+
+            pauseCount.Should().Be(2, "each Run() should see the debugger pause");
+        }
+    }
+}

--- a/Tests/Noesis.Javascript.Tests/DebuggerTests.cs
+++ b/Tests/Noesis.Javascript.Tests/DebuggerTests.cs
@@ -242,6 +242,72 @@ namespace Noesis.Javascript.Tests
         }
 
         [TestMethod]
+        public async Task DisposingWhilePausedCompletesScriptAndSkipsRemainingBreakpoints()
+        {
+            // Verifies that disposing the debugger while paused at the first of two
+            // debugger statements allows the script to complete with the correct return
+            // value, and that the second debugger statement does not trigger another pause.
+            var debugger = new JavascriptDebugger(_context, false);
+
+            int pauseCount = 0;
+            var firstPausedTcs = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            debugger.MessageReceived += (_, e) =>
+            {
+                var json = JsonDocument.Parse(e.Message);
+                if (json.RootElement.TryGetProperty("method", out var method) &&
+                    method.GetString() == "Debugger.paused")
+                {
+                    pauseCount++;
+                    firstPausedTcs.TrySetResult();
+                }
+            };
+
+            debugger.SendCommand("{\"id\":1,\"method\":\"Debugger.enable\"}");
+
+            // Script pauses at first debugger statement; second would pause again if
+            // the debugger were still connected.
+            var runTask = Task.Run(() => _context.Run("debugger; debugger; 99;"));
+
+            // Wait for first pause, then give the V8 thread time to enter runMessageLoopOnPause.
+            await firstPausedTcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+            Thread.Sleep(50);
+            debugger.IsPaused.Should().BeTrue();
+
+            // Dispose while paused - unblocks the V8 thread and disconnects the session.
+            debugger.Dispose();
+
+            // Script should complete with the correct return value.
+            var result = await runTask.WaitAsync(TimeSpan.FromSeconds(5));
+            result.Should().Be(99);
+
+            // Only the first debugger statement should have fired a pause event.
+            pauseCount.Should().Be(1, "second debugger statement should be skipped after dispose");
+            debugger.IsConnected.Should().BeFalse();
+        }
+
+        [TestMethod]
+        public async Task DisposingWhileWaitingForDebuggerAllowsScriptToComplete()
+        {
+            // Verifies that disposing the debugger while ProcessPending() is blocked
+            // in the waitingForDebugger loop (waitForDebugger=true, no
+            // Runtime.runIfWaitingForDebugger sent) unblocks the V8 thread and
+            // allows the script to complete with the correct return value.
+            var debugger = new JavascriptDebugger(_context, true);
+
+            var runTask = Task.Run(() => _context.Run("42;"));
+            Thread.Sleep(100);
+            debugger.IsPaused.Should().BeTrue("should be blocked waiting for debugger to attach");
+            runTask.IsCompleted.Should().BeFalse("script should not have started yet");
+
+            // Dispose without ever sending Runtime.runIfWaitingForDebugger.
+            debugger.Dispose();
+
+            var result = await runTask.WaitAsync(TimeSpan.FromSeconds(5));
+            result.Should().Be(42);
+            debugger.IsConnected.Should().BeFalse();
+        }
+
+        [TestMethod]
         public void SendCommandThrowsWhenDisposed()
         {
             var debugger = new JavascriptDebugger(_context, false);


### PR DESCRIPTION
Adds debugger support for debugging the V8 instance using the [Chrome DevTools Protocol](https://chromedevtools.github.io/devtools-protocol/):

```
using var context = new JavascriptContext();
using var debugger = new JavascriptDebugger(context, false);
debugger.MessageReceived += (s, e) => Console.WriteLine(e.Message);

// Queue setup commands before running (processed at start of Run())
debugger.SendCommand("{\"id\":1,\"method\":\"Debugger.enable\"}");
debugger.SendCommand("{\"id\":2,\"method\":\"Debugger.setBreakpointByUrl\",...}");

context.Run(script);

// When paused at a breakpoint, MessageReceived fires with "Debugger.paused"
// Send resume/step commands from any thread via SendCommand()
```